### PR TITLE
Prefix encrypted mailto links with hash to prevent navigation

### DIFF
--- a/src/_lib/encrypt-emails.js
+++ b/src/_lib/encrypt-emails.js
@@ -26,7 +26,7 @@ const encryptEmailsInHtml = (content) => {
   // Encrypt existing mailto links
   for (const link of document.querySelectorAll('a[href^="mailto:"]')) {
     link.textContent = encrypt(link.textContent, keyBytes);
-    link.setAttribute("href", encrypt(link.getAttribute("href"), keyBytes));
+    link.setAttribute("href", "#" + encrypt(link.getAttribute("href"), keyBytes));
     link.setAttribute("data-decrypt-link", "");
   }
 

--- a/src/assets/js/decrypt-emails.js
+++ b/src/assets/js/decrypt-emails.js
@@ -92,7 +92,7 @@
       for (var idx = 0; idx < links.length; idx++) {
         (function (link) {
           Promise.all([
-            decrypt(link.getAttribute("href"), key),
+            decrypt(link.getAttribute("href").replace(/^#/, ""), key),
             decrypt(link.textContent, key),
           ]).then(function (results) {
             link.setAttribute("href", results[0]);


### PR DESCRIPTION
## Summary
Modified the email encryption/decryption flow to prefix encrypted mailto links with a hash (`#`) character. This prevents browsers from attempting to navigate to the encrypted href value while maintaining the ability to decrypt and restore the original mailto link on demand.

## Key Changes
- **encrypt-emails.js**: Updated encrypted mailto link href attributes to be prefixed with `#` before the encrypted value
- **decrypt-emails.js**: Updated the decryption logic to strip the leading `#` character before decrypting the href attribute

## Implementation Details
The hash prefix serves as a safety mechanism to ensure encrypted email links don't trigger unintended navigation behavior. When a user clicks an encrypted email link, the browser will treat it as a fragment identifier rather than attempting to navigate to the encrypted string. The decryption handler then removes this prefix before decrypting and restoring the original mailto link functionality.

https://claude.ai/code/session_01GjxCAHCTXHu3FE6x1mVbXB