### PR TITLE
Replace textContent with innerHTML for email encryption

### DIFF
--- a/src/_lib/encrypt-emails.js
+++ b/src/_lib/encrypt-emails.js
@@ -25,7 +25,7 @@ const encryptEmailsInHtml = (content) => {
 
   // Encrypt existing mailto links
   for (const link of document.querySelectorAll('a[href^="mailto:"]')) {
-    link.textContent = encrypt(link.textContent, keyBytes);
+    link.innerHTML = encrypt(link.innerHTML, keyBytes);
     link.setAttribute("href", "#" + encrypt(link.getAttribute("href"), keyBytes));
     link.setAttribute("data-decrypt-link", "");
   }

--- a/src/assets/js/decrypt-emails.js
+++ b/src/assets/js/decrypt-emails.js
@@ -93,10 +93,10 @@
         (function (link) {
           Promise.all([
             decrypt(link.getAttribute("href").replace(/^#/, ""), key),
-            decrypt(link.textContent, key),
+            decrypt(link.innerHTML, key),
           ]).then(function (results) {
             link.setAttribute("href", results[0]);
-            link.textContent = results[1];
+            link.innerHTML = results[1];
           });
         })(links[idx]);
       }


### PR DESCRIPTION
## Summary
Updated email encryption/decryption logic to use `innerHTML` instead of `textContent` for handling email link display text. This allows for proper handling of HTML content within encrypted email links.

## Key Changes
- **decrypt-emails.js**: Changed decryption of link text from `textContent` to `innerHTML` (both read and write operations)
- **encrypt-emails.js**: Changed encryption of link text from `textContent` to `innerHTML`

## Implementation Details
The change from `textContent` to `innerHTML` enables the email encryption system to:
- Preserve HTML formatting and entities in encrypted email link text
- Handle cases where the link text may contain HTML markup rather than plain text
- Maintain consistency between encryption and decryption operations

This is a targeted fix that affects all three operations: reading encrypted content, writing decrypted content, and reading content during encryption.

https://claude.ai/code/session_01L8xgLZvwDQ6Gy3vcScjrpW