### PR TITLE
Clarify hosting pricing and support options in service pages

### DIFF
--- a/src/services.md
+++ b/src/services.md
@@ -16,7 +16,7 @@ Whether you need a [new website](/services/static-websites/#content), a [custom 
 
 **Transparent pricing:** I charge a [flat hourly rate](/prices/) for all jobs, with a clear breakdown of what each hour covers. No hidden fees, no surprise invoices.
 
-**Fast sites, low running costs:** I build websites that load quickly on any device, giving you a strong technical foundation for search and keeping your hosting costs low - often under £10 per month for typical brochure sites.
+**Fast sites, low running costs:** I build websites that load quickly on any device, giving you a strong technical foundation for search and keeping your hosting costs low - I can host typical brochure sites for **£10/month** (or **£5/month** for charities and other discounted groups) without support included. See my [prices page](/prices/#content) for managed hosting options that include ongoing support.
 
 **Works for everyone:** I build sites that are easy to use on phones, tablets, and desktops, and accessible to visitors with visual impairments.
 

--- a/src/services/static-websites.md
+++ b/src/services/static-websites.md
@@ -4,7 +4,7 @@ meta_title: Fast, Affordable Websites | Prestwich, Manchester | Chobble
 description: Websites that load quickly, cost very little to host, and that you can edit yourself.
 snippet: Fast, affordable websites you can edit yourself
 order: -1
-meta_description: Fast websites that load in under a second, cost under £10/month to host, and that you fully own - easy to edit yourself - Prestwich developer - 50% off for charities and artists
+meta_description: Fast websites that load in under a second, hosted from £10/month (£5 for charities) without support, and that you fully own - easy to edit yourself - Prestwich developer - 50% off for charities and artists
 ---
 
 # Fast, affordable websites you own
@@ -13,7 +13,7 @@ meta_description: Fast websites that load in under a second, cost under £10/mon
 
 Platforms like WordPress, Wix, and Squarespace are designed to do everything, but most businesses only need a fraction of what they offer. The result? Websites that are slow to load, expensive to host, and hard to leave when you want to.
 
-I take a different approach. I build clean, fast, mobile-friendly websites tailored to your business. Because they're built efficiently, they **load fast** (pages feel instant once you're browsing, thanks to background preloading), **cost very little to host** (often under £10/month for typical small brochure sites), and **you own all the code** - so you're never locked in.
+I take a different approach. I build clean, fast, mobile-friendly websites tailored to your business. Because they're built efficiently, they **load fast** (pages feel instant once you're browsing, thanks to background preloading), **cost very little to host** (I can host typical small brochure sites for **£10/month**, or **£5/month** for charities and other discounted groups - no support included; see my [prices page](/prices/#content) for managed hosting with support), and **you own all the code** - so you're never locked in.
 
 You don't need to be technical — if you can edit a document, you can update your site.
 


### PR DESCRIPTION
## Summary
Updated service page descriptions to provide clearer, more transparent information about hosting costs and support options. The changes distinguish between basic hosting (without support) and managed hosting (with support included).

## Key Changes
- **Static websites service page**: Updated meta description and main content to specify that basic hosting starts at £10/month (£5/month for charities) without support included, with a link to the prices page for managed hosting options
- **Services overview page**: Revised the "Fast sites, low running costs" section to clarify hosting pricing tiers and direct users to the prices page for support options

## Notable Details
- Pricing is now explicitly stated as "without support included" for the base tier to set clear expectations
- Added cross-references to the prices page (`/prices/#content`) to help users find detailed information about managed hosting with support
- Maintained the 50% discount messaging for charities and other eligible groups
- Changes apply consistently across both service pages for messaging coherence

https://claude.ai/code/session_01Fqt7ZRApsSrjnRHsoqdogP