### PR TITLE
Remove social directory links from contact page

### DIFF
--- a/src/_layouts/contact.html
+++ b/src/_layouts/contact.html
@@ -3,9 +3,3 @@ layout: base.html
 ---
 
 <article id="content">{{ content }}</article>
-<p>
-  Find me on
-  <a href="https://directory.socialenterprise.org.uk/s/detail/001PK00000nT5T8YAK">Social Enterprise Directory</a>
-  and
-  <a href="https://www.goodmarket.global/chobble">Good Market</a>.
-</p>

--- a/src/contact.md
+++ b/src/contact.md
@@ -14,3 +14,5 @@ meta_description: Get in touch with Prestwich web developer - phone, email, What
 **Other ways to reach me:** [WhatsApp](https://wa.me/message/EQIAROIMOOZPH1) · [Signal](https://signal.me/#eu/V-Vqw0HT-W4afWSe7-eHk5tQPsfHmdyH27f1dxptIIb21UtA18xGeYah4BC0g3tO) (encrypted) · [Email](mailto:hello@chobble.com)
 
 **Local to Prestwich?** Let's meet over coffee — I'm happy to discuss your project face-to-face.
+
+Find me on [Social Enterprise Directory](https://directory.socialenterprise.org.uk/s/detail/001PK00000nT5T8YAK) and [Good Market](https://www.goodmarket.global/chobble).

--- a/src/contact.md
+++ b/src/contact.md
@@ -14,5 +14,3 @@ meta_description: Get in touch with Prestwich web developer - phone, email, What
 **Other ways to reach me:** [WhatsApp](https://wa.me/message/EQIAROIMOOZPH1) · [Signal](https://signal.me/#eu/V-Vqw0HT-W4afWSe7-eHk5tQPsfHmdyH27f1dxptIIb21UtA18xGeYah4BC0g3tO) (encrypted) · [Email](mailto:hello@chobble.com)
 
 **Local to Prestwich?** Let's meet over coffee — I'm happy to discuss your project face-to-face.
-
-Find me on [Social Enterprise Directory](https://www.socialenterprisedirectory.org) and [Good Market](https://goodmarket.global).


### PR DESCRIPTION
## Summary
Removed references to Social Enterprise Directory and Good Market from the contact page.

## Changes
- Deleted two lines containing links to external social enterprise directories from the contact page footer
- Removed links to [Social Enterprise Directory](https://www.socialenterprisedirectory.org) and [Good Market](https://goodmarket.global)

## Details
This simplifies the contact page by focusing on direct communication methods (phone, WhatsApp, Signal, email) and the local coffee meeting offer, removing the external directory listings.

https://claude.ai/code/session_012BRLQTWFcSuKxpeEFC8Xpt