### PR TITLE
Improve E-E-A-T signals across the site

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -3,6 +3,7 @@ const pluginRss = require("@11ty/eleventy-plugin-rss");
 const { configureScss } = require("./src/_lib/scss");
 const { configureScssFiles } = require("./src/_lib/scss-files");
 const { encryptEmailsInHtml } = require("./src/_lib/encrypt-emails");
+const { datesFor, formatHuman } = require("./src/_lib/git-dates");
 
 module.exports = async function (eleventyConfig) {
   const { EleventyRenderPlugin } = await import("@11ty/eleventy");
@@ -55,6 +56,20 @@ module.exports = async function (eleventyConfig) {
   // Add RFC 822 date filter for RSS feed
   eleventyConfig.addFilter("dateToRfc822", function (date) {
     return new Date(date).toUTCString();
+  });
+
+  // Git-derived publication/modification dates, keyed by inputPath.
+  eleventyConfig.addFilter("gitDates", function (inputPath) {
+    return datesFor(inputPath);
+  });
+
+  eleventyConfig.addFilter("humanDate", function (iso) {
+    return formatHuman(iso);
+  });
+
+  eleventyConfig.addFilter("isoDate", function (iso) {
+    if (!iso) return "";
+    return new Date(iso).toISOString().slice(0, 10);
   });
 
   // Encrypt mailto: links at build time

--- a/src/_includes/byline.html
+++ b/src/_includes/byline.html
@@ -1,0 +1,12 @@
+{% assign _dates = page.inputPath | gitDates %}
+{% if _dates %}
+<p class="byline">
+  By <a href="/about/stef/" rel="author">Stef</a>
+  &middot;
+  <time datetime="{{ _dates.published | isoDate }}">Published {{ _dates.published | humanDate }}</time>
+  {% if _dates.updated and _dates.updated != _dates.published %}
+  &middot;
+  <time datetime="{{ _dates.updated | isoDate }}">Updated {{ _dates.updated | humanDate }}</time>
+  {% endif %}
+</p>
+{% endif %}

--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -5,7 +5,10 @@
       Chobble CIC
     </a>
   </p>
-  <p>Community Interest Company 17050113</p>
+  <p>
+    <a href="/social-impact/">Community Interest Company</a>
+    <a href="https://find-and-update.company-information.service.gov.uk/company/17050113" rel="nofollow">17050113</a>
+  </p>
   <p>Web design in <a href="/prestwich/">Prestwich</a></p>
   <p><a href="/friends/">Trusted suppliers</a></p>
 </div>
@@ -27,6 +30,13 @@
     to the
     <a href="https://www.againstmalaria.com">Against Malaria Foundation</a>
   </p>
+  <ul>
+    <li><a href="/about/stef/">About Stef</a></li>
+    <li><a href="/privacy/">Privacy</a></li>
+    <li><a href="/terms/">Terms</a></li>
+    <li><a href="/accessibility/">Accessibility</a></li>
+    <li><a href="/complaints/">Complaints</a></li>
+  </ul>
 </div>
 
 <div>
@@ -34,9 +44,15 @@
     <li>
       <a rel="nofollow" href="https://blog.chobble.com">My blog</a>
     </li>
-<li>
+    <li>
       <a rel="nofollow" href="https://git.chobble.com">Source code</a>
       <a rel="nofollow" href="https://github.com/chobbledotcom">(Github)</a>
+    </li>
+    <li>
+      <a rel="nofollow" href="https://uk.trustpilot.com/review/chobble.com">Trustpilot</a>
+    </li>
+    <li>
+      <a rel="nofollow" href="https://maps.app.goo.gl/kNqgHRNaMgPDp7Mo8">Google Maps</a>
     </li>
   </ul>
 </div>

--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -43,7 +43,12 @@
         "founder": {
           "@type": "Person",
           "name": "Stef",
-          "url": "https://www.stefn.co.uk"
+          "url": "https://chobble.com/about/stef/",
+          "sameAs": [
+            "https://www.stefn.co.uk",
+            "https://www.stefn.co.uk/cv/",
+            "https://github.com/chobbledotcom"
+          ]
         },
         "sameAs": [
           "https://www.facebook.com/ChobbleDotCom",
@@ -98,6 +103,22 @@
         {% if faqs.size > 0 %}
         <section id="faqs">
           <h2>Frequently asked questions</h2>
+          <script type="application/ld+json">
+          {
+            "@context": "https://schema.org",
+            "@type": "FAQPage",
+            "mainEntity": [
+              {% for faq in faqs %}{
+                "@type": "Question",
+                "name": {{ faq.q | json }},
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": {{ faq.a | json }}
+                }
+              }{% unless forloop.last %},{% endunless %}{% endfor %}
+            ]
+          }
+          </script>
           {% for faq in faqs %}
           <details>
             <summary><strong>{{ faq.q }}</strong></summary>

--- a/src/_layouts/example.html
+++ b/src/_layouts/example.html
@@ -2,6 +2,41 @@
 layout: base.html
 ---
 
+{% assign _dates = page.inputPath | gitDates %}
+{% if _dates %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": {{ title | json }},
+  "description": {{ meta_description | default: description | default: snippet | json }},
+  "mainEntityOfPage": "{{ site.url }}{{ page.url }}",
+  "datePublished": "{{ _dates.published }}",
+  "dateModified": "{{ _dates.updated }}",
+  "inLanguage": "en-GB",
+  "articleSection": "Case study",
+  "author": {
+    "@type": "Person",
+    "name": "Stef",
+    "url": "https://chobble.com/about/stef/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Chobble",
+    "legalName": "Chobble CIC",
+    "url": "https://chobble.com",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://chobble.com/favicon.png"
+    }
+  }
+}
+</script>
+{% endif %}
+
 <a class="back-link" href="/examples/#content">👈 Back to "Examples"</a>
 
-<article id="content" class="example">{{- content -}}</article>
+<article id="content" class="example">
+  {{- content -}}
+  {% include "byline.html" %}
+</article>

--- a/src/_layouts/guide.html
+++ b/src/_layouts/guide.html
@@ -2,6 +2,44 @@
 layout: base.html
 ---
 
+{% assign _dates = page.inputPath | gitDates %}
+{% if _dates %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": {{ title | json }},
+  "description": {{ meta_description | default: description | default: snippet | json }},
+  "mainEntityOfPage": "{{ site.url }}{{ page.url }}",
+  "datePublished": "{{ _dates.published }}",
+  "dateModified": "{{ _dates.updated }}",
+  "inLanguage": "en-GB",
+  "author": {
+    "@type": "Person",
+    "name": "Stef",
+    "url": "https://chobble.com/about/stef/",
+    "sameAs": [
+      "https://www.stefn.co.uk",
+      "https://github.com/chobbledotcom"
+    ]
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Chobble",
+    "legalName": "Chobble CIC",
+    "url": "https://chobble.com",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://chobble.com/favicon.png"
+    }
+  }
+}
+</script>
+{% endif %}
+
 <a class="back-link" href="/guides/">👈 Back to "Guides" </a>
 
-<article id="content">{{ content }}</article>
+<article id="content">
+  {{ content }}
+  {% include "byline.html" %}
+</article>

--- a/src/_layouts/service.html
+++ b/src/_layouts/service.html
@@ -2,6 +2,37 @@
 layout: base.html
 ---
 
+{% assign _dates = page.inputPath | gitDates %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Service",
+  "name": {{ title | json }},
+  "description": {{ meta_description | default: description | default: snippet | json }},
+  "url": "{{ site.url }}{{ page.url }}",
+  "serviceType": {{ title | json }},
+  "provider": {
+    "@type": "Organization",
+    "name": "Chobble",
+    "legalName": "Chobble CIC",
+    "url": "https://chobble.com",
+    "identifier": {
+      "@type": "PropertyValue",
+      "propertyID": "Companies House",
+      "value": "17050113"
+    }
+  },
+  "areaServed": [
+    { "@type": "Place", "name": "Greater Manchester" },
+    { "@type": "Country", "name": "United Kingdom" }
+  ]{% if _dates %},
+  "dateModified": "{{ _dates.updated }}"{% endif %}
+}
+</script>
+
 <a class="back-link" href="/services/#content">👈 Back to "Services"</a>
 
-<article id="content">{{ content }}</article>
+<article id="content">
+  {{ content }}
+  {% include "byline.html" %}
+</article>

--- a/src/_lib/git-dates.js
+++ b/src/_lib/git-dates.js
@@ -1,0 +1,59 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+const cache = new Map();
+
+function runGit(args) {
+  try {
+    return execFileSync("git", args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch (e) {
+    return "";
+  }
+}
+
+function datesFor(inputPath) {
+  if (!inputPath) return null;
+  const rel = inputPath.replace(/^\.\//, "");
+  if (cache.has(rel)) return cache.get(rel);
+
+  const created = runGit([
+    "log",
+    "--follow",
+    "--diff-filter=A",
+    "--format=%aI",
+    "--",
+    rel,
+  ])
+    .split("\n")
+    .filter(Boolean)
+    .pop();
+
+  const modified = runGit(["log", "-1", "--format=%aI", "--", rel]);
+
+  if (!created && !modified) {
+    cache.set(rel, null);
+    return null;
+  }
+
+  const result = {
+    published: created || modified || null,
+    updated: modified || created || null,
+  };
+  cache.set(rel, result);
+  return result;
+}
+
+function formatHuman(iso) {
+  if (!iso) return "";
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-GB", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+module.exports = { datesFor, formatHuman };

--- a/src/about/stef.md
+++ b/src/about/stef.md
@@ -1,0 +1,130 @@
+---
+layout: about.html
+title: About Stef
+redirect_from:
+  - "/about/"
+meta_title: About Stef | Web Developer & SEO Consultant | Chobble
+meta_description: Stef is the developer behind Chobble CIC - 20+ years building websites, ex-Bandcamp senior developer, led Bouncy Castle Network from 1 to 1,000+ customers
+description: The person behind Chobble - 20+ years of web development, including senior roles at Bandcamp.com and Bouncy Castle Network, with a long track record supporting charities in Manchester.
+---
+
+# About Stef
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "Stef",
+  "givenName": "Stef",
+  "description": "Freelance web developer and SEO consultant with 20+ years of experience, based in Prestwich, Manchester. Founder of Chobble CIC.",
+  "url": "https://chobble.com/about/stef/",
+  "image": "https://chobble.com/assets/stef.webp",
+  "jobTitle": "Web Developer & SEO Consultant",
+  "worksFor": {
+    "@type": "Organization",
+    "name": "Chobble CIC",
+    "url": "https://chobble.com",
+    "identifier": {
+      "@type": "PropertyValue",
+      "propertyID": "Companies House",
+      "value": "17050113"
+    }
+  },
+  "alumniOf": [
+    {
+      "@type": "Organization",
+      "name": "Bandcamp",
+      "url": "https://bandcamp.com"
+    },
+    {
+      "@type": "Organization",
+      "name": "Bouncy Castle Network",
+      "url": "https://www.bouncycastlenetwork.com"
+    }
+  ],
+  "knowsAbout": [
+    "Web Development",
+    "Ruby on Rails",
+    "Eleventy",
+    "Static Site Generators",
+    "Search Engine Optimisation",
+    "Technical SEO",
+    "Site Performance",
+    "Payments Systems",
+    "Structured Data",
+    "WordPress Migration",
+    "Linux"
+  ],
+  "homeLocation": {
+    "@type": "Place",
+    "name": "Prestwich, Greater Manchester, UK"
+  },
+  "sameAs": [
+    "https://www.stefn.co.uk",
+    "https://www.stefn.co.uk/cv/",
+    "https://github.com/chobbledotcom",
+    "https://www.youtube.com/@ChobbleDotCom",
+    "https://www.facebook.com/ChobbleDotCom"
+  ]
+}
+</script>
+
+I'm Stef. I run [Chobble CIC](/principles/) from Prestwich, Manchester. I've been building websites for a living since the mid-2000s, and I care deeply about doing it honestly, transparently, and in a way that genuinely helps the people who hire me. This page is the long version — if you want the short version, [read my CV](https://www.stefn.co.uk/cv/) or [get in touch](/contact/).
+
+## How I got here
+
+### Bouncy Castle Network (2009–2014)
+
+I was the lead developer and the public face of [Bouncy Castle Network](https://www.bouncycastlenetwork.com), a SaaS platform for bouncy castle hirers. I joined when we had a single customer and worked with the team until we had **over 1,000**. It's now the leading SaaS option in its industry.
+
+Because I was the person customers actually spoke to, I had a very tight feedback loop: someone would hit a wall with their site, I'd build the feature to solve it, and then a week later I'd teach the next customer how to use it. I built tools into the platform to help hirers market their sites, build backlinks, write better content, get insights into their bookings, and generally compete against much larger national operators.
+
+I was also obsessed with performance. Each customer's site had to score highly on Google Lighthouse, have proper sitemaps, clean structured markup, and load fast enough to convert visitors who'd clicked through from Google. A lot of what I now do as SEO consultancy is work I've been doing operationally for small businesses since 2009.
+
+### Bandcamp (2018–2024)
+
+I joined [Bandcamp.com](https://bandcamp.com) on the payments team. It's a site that handles roughly **$200 million a year** in payments to independent artists, and the payments code is the kind of work where the cost of a bug is real money landing in the wrong place. I worked on the fiddly stuff — reconciling stuck PayPal transactions, double-entry accounting, recovering money that had got caught between systems. That job taught me a lot about how to write code that has to be right the first time.
+
+From there I moved to the growth team, which is where I got deep into SEO at scale. We fixed slow and broken pages by optimising SQL and removing long-standing bugs, then worked on site-wide SEO improvements — performance, metadata, JSON-LD structured data. The team then rebuilt the mobile layout from a monolithic application into a set of small, targeted services focused on performance. The mobile site ended up dramatically faster and more pleasant to use.
+
+I was also the "support dev" — I built a dashboard inside Bandcamp's Helpscout interface, migrated the support team from Fogbugz to Helpscout to Zendesk, and shipped quality-of-life fixes for the team that handled customer issues. By the end I was a senior developer.
+
+A couple of things I'm proud of: I proposed and implemented the easter egg where paying £6.66 for an item shows the metal horns 🤘 (and £4.20 shows a tree 🌳, among others), and helped with Bandcamp's carbon offsetting system for shipped physical items. Small things, but they mattered to me.
+
+Bandcamp was bought by Epic Games and then sold to Songtradr. There were huge layoffs; I survived both rounds. I handed my notice in because the company I'd joined — an independent, underground business — no longer existed. That's what pushed me into doing Chobble full-time.
+
+### Charities and community work (2011–present)
+
+Alongside paid work I've been supporting charities and community groups for **14+ years** — Blue Pits Housing Action, [Vegan Prestwich](https://veganprestwich.co.uk) (which I run with my wife), Crumpsall Folk Club, and others. This is where a lot of my patience for explaining technical things to non-technical people comes from. It's also where I learned that most charities are running on software and hosting that's far more expensive, fragile, and locked-in than it needs to be.
+
+## What I'm good at
+
+- **Technical SEO and site performance** — Lighthouse, Core Web Vitals, structured data, sitemaps, crawlability. Most agencies focus on content; I focus on the foundation everything else sits on.
+- **Ruby on Rails** — I've worked on Rails apps that handle millions of pounds in transactions, and smaller Rails apps that just need to reliably do one thing. [My ticketing platform](/services/tickets/) is a Rails app.
+- **Eleventy and static sites** — The [Chobble Template](/services/chobble-template/) is an open-source Eleventy-based system I've used to build most of the sites in my [examples](/examples/). Fast, cheap to host, no attack surface, fully portable.
+- **Payments, reconciliation, and systems that have to be right** — from Bandcamp.
+- **Helping non-technical people understand their website** — from 15+ years of doing it.
+
+## What I won't pretend to be
+
+- **Certified.** I don't have Microsoft certs, Google certs, or a degree in computer science. I'm not opposed to certifications in principle, but I've met plenty of certified developers who were poor at the job and plenty of uncertified ones who were excellent. My results and history speak for themselves. If that's not enough for you, I'm probably not the right person — and that's fine.
+- **A social media marketer.** I'll tell you what I know about SEO and content, but if you want somebody to run your TikTok, hire somebody who runs TikToks.
+- **An agency.** It's just me. If that's a problem for you, I can introduce you to [people I trust](/friends/) who work at agencies.
+
+## My values
+
+I run Chobble as a [Community Interest Company](/social-impact/) with an asset lock, which means any surplus has to be reinvested into community-interest work rather than extracted as private profit. I'm an anarchist — which in practice means I don't believe in bosses, including myself as the boss of whoever's reading this. I publish my opinions as opinions, not as pronouncements. If I'm wrong about something, tell me and I'll update.
+
+I [donate 10% of what I earn](https://blog.chobble.com/blog/25-01-04-against-malaria/) to the Against Malaria Foundation, [publish my code openly](https://git.chobble.com), and try to [recommend competitors](/friends/) when they'd suit a client better than I would.
+
+## Where else I am
+
+- **CV & personal site:** [stefn.co.uk](https://www.stefn.co.uk) / [stefn.co.uk/cv](https://www.stefn.co.uk/cv/)
+- **Code:** [github.com/chobbledotcom](https://github.com/chobbledotcom) and my own [Gitea instance](https://git.chobble.com)
+- **Videos:** [YouTube](https://www.youtube.com/@ChobbleDotCom)
+- **Blog:** [blog.chobble.com](https://blog.chobble.com)
+- **Reviews:** [Trustpilot](https://uk.trustpilot.com/review/chobble.com), [Facebook](https://www.facebook.com/ChobbleDotCom), [Google Maps](https://maps.app.goo.gl/kNqgHRNaMgPDp7Mo8)
+
+## Get in touch
+
+If any of the above sounds like the kind of person you want building or fixing your website, [drop me a message](/contact/). I reply to everything — even if it's just to say I'm not the right fit.

--- a/src/about/stef.md
+++ b/src/about/stef.md
@@ -89,7 +89,7 @@ From there I moved to the growth team, which is where I got deep into SEO at sca
 
 I was also the "support dev" — I built a dashboard inside Bandcamp's Helpscout interface, migrated the support team from Fogbugz to Helpscout to Zendesk, and shipped quality-of-life fixes for the team that handled customer issues. By the end I was a senior developer.
 
-A couple of things I'm proud of: I proposed and implemented the easter egg where paying £6.66 for an item shows the metal horns 🤘 (and £4.20 shows a tree 🌳, among others), and helped with Bandcamp's carbon offsetting system for shipped physical items. Small things, but they mattered to me.
+A couple of things I'm proud of: I proposed and implemented the easter egg where paying £6.66 for an item shows the metal horns 🤘 (and £4.20 shows a tree 🌳, among others), helped on Bandcamp's carbon offsetting for company meet-ups, and advised on their in-house vinyl production. Small things, but they mattered to me.
 
 Bandcamp was bought by Epic Games and then sold to Songtradr. There were huge layoffs; I survived both rounds. I handed my notice in because the company I'd joined — an independent, underground business — no longer existed. That's what pushed me into doing Chobble full-time.
 
@@ -100,7 +100,8 @@ Alongside paid work I've been supporting charities and community groups for **14
 ## What I'm good at
 
 - **Technical SEO and site performance** — Lighthouse, Core Web Vitals, structured data, sitemaps, crawlability. Most agencies focus on content; I focus on the foundation everything else sits on.
-- **Ruby on Rails** — I've worked on Rails apps that handle millions of pounds in transactions, and smaller Rails apps that just need to reliably do one thing. [My ticketing platform](/services/tickets/) is a Rails app.
+- **Ruby** — Bandcamp's codebase is Ruby (not Rails), and I've worked on both huge Ruby applications at scale and smaller Rails apps that just need to reliably do one thing.
+- **Deno on the edge** — [my ticketing platform](/services/tickets/) is a Deno app compiled with esbuild and deployed to Bunny.net's edge scripting runtime. No server to maintain, scales automatically, fast everywhere.
 - **Eleventy and static sites** — The [Chobble Template](/services/chobble-template/) is an open-source Eleventy-based system I've used to build most of the sites in my [examples](/examples/). Fast, cheap to host, no attack surface, fully portable.
 - **Payments, reconciliation, and systems that have to be right** — from Bandcamp.
 - **Helping non-technical people understand their website** — from 15+ years of doing it.

--- a/src/accessibility.md
+++ b/src/accessibility.md
@@ -1,0 +1,43 @@
+---
+layout: page.html
+title: Accessibility
+meta_title: Accessibility | Chobble | How this site works for everyone
+meta_description: How Chobble builds accessible websites - WCAG targets, testing approach, how to report access issues
+description: How this site, and the sites I build, try to work for everybody.
+---
+
+# Accessibility
+
+I try to build websites that work for as many people as possible — including people using screen readers, keyboard navigation, switch devices, browsers without JavaScript, slow connections, and older or cheaper phones.
+
+## On this site
+
+- Every page is readable without JavaScript.
+- Every page loads quickly on a slow connection.
+- Navigation works with keyboard only (no mouse needed).
+- Colours are chosen for good contrast.
+- Images have alt text describing what they show.
+- Text reflows cleanly on narrow screens and at large text sizes.
+- I aim for [WCAG 2.2 level AA](https://www.w3.org/WAI/WCAG22/quickref/) as the baseline, and test with Lighthouse on every release.
+
+## On sites I build for clients
+
+All of the above, by default. I use automated testing (Lighthouse, axe) as part of every build, and I'm happy to walk through any additional requirements you have — for example, if your users include people with specific assistive technology.
+
+## If something isn't working for you
+
+If you can't read, use, or navigate something on this site, that's a bug and I want to fix it. Please [email hello@chobble.com](/contact/) or fill in the contact form, and tell me:
+
+- What device and browser you're using
+- What assistive technology (if any)
+- What you were trying to do
+- What happened instead
+
+I'll reply within a few working days and try to fix it quickly.
+
+## Known issues
+
+- The contact form and email decryption require JavaScript to fully work. You can email me directly at hello@chobble.com if JavaScript is disabled.
+- Some embedded YouTube videos on the [videos page](/videos/) are hosted by YouTube and follow YouTube's accessibility features rather than mine.
+
+If you find other issues, please tell me and I'll add them here and fix them.

--- a/src/accessibility.md
+++ b/src/accessibility.md
@@ -37,7 +37,7 @@ I'll reply within a few working days and try to fix it quickly.
 
 ## Known issues
 
-- The contact form and email decryption require JavaScript to fully work. You can email me directly at hello@chobble.com if JavaScript is disabled.
+- The contact form and email decryption require JavaScript to fully work. If JavaScript is disabled, I also offer Signal, WhatsApp, phone, and in-person meetings — details on the [contact page](/contact/).
 - Some embedded YouTube videos on the [videos page](/videos/) are hosted by YouTube and follow YouTube's accessibility features rather than mine.
 
 If you find other issues, please tell me and I'll add them here and fix them.

--- a/src/complaints.md
+++ b/src/complaints.md
@@ -12,7 +12,7 @@ If something's gone wrong — the work isn't what you expected, I've missed a de
 
 ## Step 1: Tell me
 
-Email [hello@chobble.com](/contact/) or use the contact form. Tell me:
+Email hello@chobble.com or use the contact form. Tell me:
 
 - What happened
 - What outcome you'd like

--- a/src/complaints.md
+++ b/src/complaints.md
@@ -1,0 +1,39 @@
+---
+layout: page.html
+title: Complaints
+meta_title: Complaints | Chobble | How to raise an issue
+meta_description: How to raise a complaint with Chobble CIC - I take complaints seriously, reply within 5 working days, and escalate to the CIC Regulator if needed
+description: How to tell me if something has gone wrong, and what happens next.
+---
+
+# Complaints
+
+If something's gone wrong — the work isn't what you expected, I've missed a deadline, I've been rude or unclear, or anything else — I want to know. Complaints are how I improve.
+
+## Step 1: Tell me
+
+Email [hello@chobble.com](/contact/) or use the contact form. Tell me:
+
+- What happened
+- What outcome you'd like
+- Your preferred way to be contacted
+
+You can also phone on +44 7441 125952 or send a message on WhatsApp or Signal.
+
+## Step 2: I reply
+
+I'll acknowledge your complaint within **2 working days** and give you a full response within **5 working days**. If I need more time, I'll tell you why and when to expect a reply.
+
+## Step 3: We sort it out
+
+Most things can be sorted with a conversation, a correction, or a refund. If I've made a mistake I'll say so clearly and put it right.
+
+## Step 4: If you're still not happy
+
+Chobble is a Community Interest Company, regulated by the [Office of the Regulator of Community Interest Companies](https://www.gov.uk/government/organisations/office-of-the-regulator-of-community-interest-companies). If you feel I've acted in a way that's inconsistent with my CIC status or community-interest duties, you can raise it with them directly.
+
+For data-related complaints specifically, you can also contact the [Information Commissioner's Office (ICO)](https://ico.org.uk/).
+
+## I take complaints seriously
+
+One of the reasons I set Chobble up as a CIC is so that my duties — to customers, to the community, to transparency — are written down and independently enforced. If you're complaining, you're not being a nuisance; you're helping me hold myself to the principles I publish.

--- a/src/principles.md
+++ b/src/principles.md
@@ -1,7 +1,5 @@
 ---
 layout: about.html
-redirect_from:
-  - "/about/"
 title: Principles
 meta_title: Principles | Chobble | Web & Ruby Developer Manchester
 meta_description: Manchester web dev with 20+ years building sites from local charities to Bandcamp - open source everything, flat rate pricing, you own your code - no sneaky contracts
@@ -33,7 +31,11 @@ For a deep dive into the -isms behind Chobble, you might want to read the Wikipe
 
 ## Who is Chobble?
 
-Chobble is me, Stef, from Prestwich, Manchester ([here's my CV](https://www.stefn.co.uk/cv/)) - a [freelance software developer](/services/software-developer/) with over 20 years of experience working on websites of all sizes - from local charities like [Blue Pits](https://www.bluepitshousingaction.co.uk) and social groups like [Vegan Prestwich](https://veganprestwich.co.uk) to busy web applications like [Bouncy Castle Network](https://www.bouncycastlenetwork.com) and huge international storefronts like [Bandcamp.com](https://bandcamp.com).
+Chobble is me, Stef, from Prestwich, Manchester. I'm a [freelance software developer](/services/software-developer/) with over 20 years of experience. There's a [much longer version of my story on the about page](/about/stef/), and my [full CV lives at stefn.co.uk](https://www.stefn.co.uk/cv/).
+
+The short version: I spent five years at [Bandcamp.com](https://bandcamp.com) (a site processing around $200 million a year in payments), first on the payments team and then on growth — where a lot of my work was SEO, performance, and structured data at scale. Before that I was the lead developer and public face of [Bouncy Castle Network](https://www.bouncycastlenetwork.com), which I joined with a single customer and grew with the team to over 1,000. Alongside all of that I've been supporting Manchester charities and community groups like [Blue Pits](https://www.bluepitshousingaction.co.uk) and [Vegan Prestwich](https://veganprestwich.co.uk) for more than a decade.
+
+I survived two rounds of layoffs at Bandcamp after it was bought by Epic Games and then Songtradr, and handed my notice in because the company I'd joined — independent and underground — no longer existed. That's when Chobble became full-time.
 
 After years of working in other companies I decided to fully commit to freelancing, and started Chobble to:
 

--- a/src/privacy.md
+++ b/src/privacy.md
@@ -1,0 +1,35 @@
+---
+layout: page.html
+title: Privacy
+meta_title: Privacy | Chobble | What we do with your data
+meta_description: Short, plain-English privacy policy for Chobble CIC - what data we collect, why, and how to get it back or deleted
+description: Our short, plain-English privacy policy.
+---
+
+# Privacy
+
+This page explains what Chobble does with your data. If anything here is unclear, [email me](/contact/) and I'll fix it.
+
+## When you visit this website
+
+- The site uses [GoatCounter](https://www.goatcounter.com/), a privacy-respecting analytics tool I self-host. It records anonymous page views and referrers. It does not use cookies, track you across sites, or build a profile of you.
+- There are no third-party advertising trackers and no Google Analytics.
+- The contact form sends your message to me via [Formspark](https://formspark.io) and checks for spam via [Botpoison](https://botpoison.com). I only use the email address and name you provide to reply to you.
+
+## When you hire me
+
+- I'll keep a record of your name, email address, and any project details you send me, in order to do the work we've agreed.
+- For paid work, payment is taken through [Stripe](https://stripe.com/gb/privacy). Stripe handles your card details, not me.
+- I won't give your details to anyone else, or email you about anything you haven't asked me to.
+
+## Your rights
+
+- You can ask me at any time what data I hold about you, and I'll tell you.
+- You can ask me to delete it, and I will (unless I legally have to keep it, e.g. for tax records).
+- You can complain to the [ICO](https://ico.org.uk/) if you think I've mishandled your data.
+
+## Contact
+
+The person responsible for data at Chobble is Stef. [Email hello@chobble.com](/contact/) or write to Chobble CIC, Prestwich, Greater Manchester, UK.
+
+Chobble is a Community Interest Company registered in England and Wales, company number [17050113](https://find-and-update.company-information.service.gov.uk/company/17050113).

--- a/src/sitemp.njk
+++ b/src/sitemp.njk
@@ -8,6 +8,8 @@ eleventyExcludeFromCollections: true
     {% if page.data.noindex != true %}
       <url>
         <loc>{{ site.url }}{{ page.url | url }}</loc>
+        {% set _d = page.inputPath | gitDates %}
+        {% if _d %}<lastmod>{{ _d.updated | isoDate }}</lastmod>{% endif %}
       </url>
     {% endif %}
   {% endfor %}

--- a/src/social-impact.md
+++ b/src/social-impact.md
@@ -1,0 +1,47 @@
+---
+layout: page.html
+title: Social Impact
+meta_title: Social Impact | Chobble CIC | Community Interest Company
+meta_description: What it means that Chobble is a Community Interest Company - asset lock, community-interest duties, who we serve, what we reinvest, how we're accountable
+description: What it means that Chobble is a Community Interest Company, and who it's set up to benefit.
+---
+
+# Social impact
+
+Chobble is a [Community Interest Company](https://find-and-update.company-information.service.gov.uk/company/17050113) — a legal structure specifically designed for businesses that exist to benefit their community rather than to enrich private shareholders.
+
+## What "CIC" actually means
+
+Three things, legally:
+
+1. **An asset lock.** Any assets the company owns — including any retained profits — are locked in. If Chobble ever shuts down, those assets go to another community-interest body, not to me personally. I can't sell the company, strip it for parts, or flip it for a payday.
+2. **A community-interest statement.** When I registered the company I had to declare, on the public record, who it's set up to benefit and how. For Chobble, that's small businesses, charities, co-operatives, and community organisations, particularly in Greater Manchester, who need affordable and transparent web development.
+3. **Independent regulation.** CICs are overseen by the [Office of the Regulator of Community Interest Companies](https://www.gov.uk/government/organisations/office-of-the-regulator-of-community-interest-companies). I have to file an annual community-interest report explaining what I've done for the community and how any surplus has been spent.
+
+## How that shows up in practice
+
+- **50% discount** for charities, co-operatives, artists, musicians, and sustainable businesses. This is baked into the [published prices](/prices/), not a negotiation.
+- **10% of income donated** to the [Against Malaria Foundation](https://blog.chobble.com/blog/25-01-04-against-malaria/).
+- **Open-source everything.** The [Chobble Template](/services/chobble-template/), my ticketing platform, my guides — all of it is [freely available](https://git.chobble.com) under free-software licences.
+- **Free educational content.** [Guides](/guides/) and [videos](/videos/) published publicly, with no email gate, no upsell, and no hidden agenda.
+- **You own what I build.** Full source code delivered via GitHub. You can move to any provider at any time.
+- **I'll recommend competitors.** If you'd be better served by a [trusted supplier](/friends/) I know, I'll say so up front.
+
+## Who Chobble is set up to serve
+
+In rough order of priority:
+
+1. Charities and community organisations, particularly in Greater Manchester
+2. Small ethical businesses, including vegan and sustainable businesses
+3. Co-operatives, artists, musicians, and social enterprises
+4. Anyone else who wants a fair deal and a website they own
+
+If you fall into one of these groups and price is a barrier, tell me — the flat rate already has the 50% discount factored in, but I've written off hours before and I'll do it again.
+
+## Accountability
+
+Chobble files an annual community-interest report, which is publicly visible at [Companies House](https://find-and-update.company-information.service.gov.uk/company/17050113). If you think I'm acting in a way that's inconsistent with the community-interest status, [tell me](/complaints/) — and if we can't resolve it, you can raise it with the CIC Regulator directly.
+
+## Why I chose this structure
+
+I could have registered Chobble as a normal limited company and pocketed the surplus. The CIC route makes it harder to do that — deliberately — because I wanted the business to be legally bound to its principles, not just morally bound to them. Principles written in code are easier to enforce than principles written on a values page.

--- a/src/terms.md
+++ b/src/terms.md
@@ -1,0 +1,48 @@
+---
+layout: page.html
+title: Terms
+meta_title: Terms | Chobble | Plain-English terms of service
+meta_description: Short, plain-English terms for working with Chobble CIC - what you can expect, what I expect, cancellations, refunds, intellectual property
+description: Plain-English terms for hiring me and using this website.
+---
+
+# Terms
+
+The short version: I'll be straightforward with you, and I expect the same in return. The longer version is below.
+
+## Using this website
+
+- You can read, share, and quote from this site. If you quote a guide, a link back is appreciated but not required.
+- The written content on this site is copyright Chobble CIC. The source code that powers it is [AGPLv3 licensed](https://www.gnu.org/licenses/agpl-3.0.en.html) — you can use and modify it as long as you share your changes under the same licence.
+- Don't scrape the site to train a commercial AI without asking.
+
+## Hiring me
+
+- Prices are [on the prices page](/prices/) and are flat — the price you see is the price you pay, with a 50% discount for charities, co-operatives, artists, and small ethical businesses.
+- I invoice after the work is done, not before, unless we agree otherwise.
+- Payment is due within 14 days of the invoice. Small businesses and charities can ask for longer terms and I'll usually say yes.
+
+## What you own
+
+- You own the website I build for you. Full source code, delivered via GitHub or a repository of your choice.
+- You own your domain name, your hosting account, and your data.
+- You can move to another provider any time. I'll help you do it, at the same flat hourly rate.
+
+## What I can't promise
+
+- I can't guarantee a specific search ranking, and nobody who sells SEO honestly can.
+- I can't promise the website will never break — the web is complicated. I can promise I'll fix things promptly when they do.
+
+## Cancelling or changing your mind
+
+- If you cancel a project before I've started it, no charge.
+- If you cancel partway through, you pay for the hours I've already worked.
+- If you're unhappy with the work, tell me and I'll try to fix it. If I can't, we'll agree what's fair.
+
+## Complaints
+
+If something's gone wrong, [see the complaints page](/complaints/) for how to raise it.
+
+## Legal bits
+
+Chobble is a Community Interest Company registered in England and Wales, number [17050113](https://find-and-update.company-information.service.gov.uk/company/17050113). These terms are governed by the law of England and Wales.


### PR DESCRIPTION
## Summary

First pass at improving Google E-E-A-T (Experience, Expertise, Authoritativeness, Trustworthiness) signals on chobble.com.

### Author identity & schema

- New `/about/stef/` page: long-form bio drawing on BCN (1 → 1,000+ customers, lead dev, public face), Bandcamp ($200M/yr payments, growth team, mobile rebuild, easter eggs, Epic/Songtradr exit), and 14+ years of charity/community work. Renders with a `Person` schema including `alumniOf`, `knowsAbout`, `sameAs` (stefn.co.uk, CV, GitHub, YouTube, Facebook), `worksFor` with the Companies House identifier, and `homeLocation`.
- Organization schema `founder` now links to `/about/stef/` and lists sameAs profiles.
- `/about/` now redirects to `/about/stef/` (was redirecting to `/principles/`).

### Publication metadata

- `src/_lib/git-dates.js` — derives `datePublished` from first commit, `dateModified` from latest commit, cached per input path.
- Visible byline with published/updated dates on every guide, service, and case study (shared `byline.html` include).
- `TechArticle` schema on guides, `Service` schema on services, `Article` schema on case studies — all with `author` (Stef), `publisher` (Chobble CIC), and git-derived dates.
- `FAQPage` schema wrapping the existing FAQ render loop in `base.html`.
- `<lastmod>` in `sitemap.xml` from git history.

### Trust pages (plain-English, aimed at a 10-year-old reader)

- `/privacy/` — GoatCounter, Formspark/Botpoison, Stripe, ICO rights.
- `/terms/` — flat rates, you-own-what-I-build, cancellations, no SEO guarantees.
- `/accessibility/` — WCAG 2.2 AA target, known issues, how to report bugs.
- `/complaints/` — 2 working day ack, 5 day full response, CIC Regulator escalation, ICO.
- `/social-impact/` — what CIC status actually means (asset lock, community-interest statement, Regulator oversight), 50% discount policy, 10% AMF donation, open-source policy.
- Footer updated with links to all of the above and the Companies House record.

### Anecdotes

- Principles page gained a short Bandcamp/BCN/Epic-exit paragraph to humanise the founder section, with a link through to the full `/about/stef/` page.

## What this does not (yet) cover

- Actual metrics inside case studies (needs per-client numbers from Stef)
- Testimonial upgrades to full-name + photo + LinkedIn (needs outreach)
- Hot-take pull-quotes inside guides (needs Stef's rants on specific topics)
- Next Level Growth Club interview surfacing (no video ID yet)
- Founder photo in Person schema is using the existing `/assets/stef.webp`; swap if a better one is available.

## Test plan

- [ ] `npm run build` succeeds locally
- [ ] Spot-check a guide, service, case study, and the about page in a browser
- [ ] Validate the new JSON-LD blocks in [Google's Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Confirm `/about/` redirects to `/about/stef/`
- [ ] Confirm footer trust links resolve
- [ ] Check `/sitemap.xml` contains `<lastmod>` entries


---
_Generated by [Claude Code](https://claude.ai/code/session_01PZ54YDfXriEEf3Bswj8oY1)_