### PR TITLE
Set £10/month as hosting minimum, drop £5 charity hosting claim

### DIFF
--- a/src/examples/uke-group-north.md
+++ b/src/examples/uke-group-north.md
@@ -11,7 +11,7 @@ meta_description: Website for music teachers and workshops - session listings, s
 
 If you teach music - whether that's workshops, one-to-one lessons, or both - you need a website that makes it easy for students to find you, see your session times, and get in touch. I build websites for music teachers that are straightforward to update yourself and handle all the practical bits you need.
 
-**Musicians get 50% off my standard rates** - so a basic site starts from around £100-£200, with hosting from £5/month. [Full pricing details here](/prices/#content).
+**Musicians get 50% off my standard rates** - so a basic site starts from around £100-£200, with hosting from £10/month (or host elsewhere for free since you own the code). [Full pricing details here](/prices/#content).
 
 ## Uke Group North example
 
@@ -63,7 +63,7 @@ A simple contact form or clear email address is essential, plus phone number if 
 
 ## Why this approach works for musicians
 
-You can edit it yourself - PagesCMS gives you a straightforward editor, so you don't need to pay someone every time you want to add a songbook or update session times. Static hosting is affordable at £5/month for unmanaged hosting (bug fixes only) or £20/month for managed hosting with ongoing support and marketing help.
+You can edit it yourself - PagesCMS gives you a straightforward editor, so you don't need to pay someone every time you want to add a songbook or update session times. Static hosting is affordable at £10/month for unmanaged hosting (bug fixes only) or £20/month for managed hosting with ongoing support and marketing help - or you can host elsewhere for free since you own the code.
 
 The site's source code is yours, hosted on GitHub. If you want to move elsewhere or hire a different developer, you can. Static sites don't have databases to hack or WordPress plugins to update, so they're quick to load and stable.
 
@@ -71,7 +71,7 @@ The site's source code is yours, hosted on GitHub. If you want to move elsewhere
 
 I charge £200/hour for web development (£100/hour for musicians, artists, and writers), with discussions before and after the job free. A basic music teacher website typically takes 1-3 hours to set up using my template, so you're looking at £100-£300 total.
 
-Hosting is £10/month for unmanaged (bug fixes only) or £40/month for managed hosting (updates, marketing support, bug fixes). Both are 50% off for musicians, so £5/month or £20/month respectively.
+Hosting with me starts at £10/month for unmanaged (bug fixes only). Managed hosting is £40/month (£20/month for musicians) and includes updates, marketing support, and bug fixes. £10/month is my minimum - if you want to pay less, you can host elsewhere for free since you own the code.
 
 [Full pricing details here](/prices/#content)
 

--- a/src/examples/uke-group-north.md
+++ b/src/examples/uke-group-north.md
@@ -11,7 +11,7 @@ meta_description: Website for music teachers and workshops - session listings, s
 
 If you teach music - whether that's workshops, one-to-one lessons, or both - you need a website that makes it easy for students to find you, see your session times, and get in touch. I build websites for music teachers that are straightforward to update yourself and handle all the practical bits you need.
 
-**Musicians get 50% off my standard rates** - so a basic site starts from around £100-£200, with hosting from £10/month (or host elsewhere for free since you own the code). [Full pricing details here](/prices/#content).
+**Musicians get 50% off my standard rates** - so a basic site starts from around £100-£200, with hosting-only from £5/month (or host elsewhere for free since you own the code). [Full pricing details here](/prices/#content).
 
 ## Uke Group North example
 
@@ -63,7 +63,7 @@ A simple contact form or clear email address is essential, plus phone number if 
 
 ## Why this approach works for musicians
 
-You can edit it yourself - PagesCMS gives you a straightforward editor, so you don't need to pay someone every time you want to add a songbook or update session times. Static hosting is affordable at £10/month for unmanaged hosting (bug fixes only) or £20/month for managed hosting with ongoing support and marketing help - or you can host elsewhere for free since you own the code.
+You can edit it yourself - PagesCMS gives you a straightforward editor, so you don't need to pay someone every time you want to add a songbook or update session times. Static hosting is affordable at £5/month for unmanaged hosting (bug fixes only, charity rate) or £20/month for managed hosting with ongoing support and marketing help - or you can host elsewhere for free since you own the code.
 
 The site's source code is yours, hosted on GitHub. If you want to move elsewhere or hire a different developer, you can. Static sites don't have databases to hack or WordPress plugins to update, so they're quick to load and stable.
 
@@ -71,7 +71,7 @@ The site's source code is yours, hosted on GitHub. If you want to move elsewhere
 
 I charge £200/hour for web development (£100/hour for musicians, artists, and writers), with discussions before and after the job free. A basic music teacher website typically takes 1-3 hours to set up using my template, so you're looking at £100-£300 total.
 
-Hosting with me starts at £10/month for unmanaged (bug fixes only). Managed hosting is £40/month (£20/month for musicians) and includes updates, marketing support, and bug fixes. £10/month is my minimum - if you want to pay less, you can host elsewhere for free since you own the code.
+Hosting is £10/month for unmanaged (bug fixes only) or £40/month for managed hosting (updates, marketing support, bug fixes). Both are 50% off for musicians, so £5/month or £20/month respectively - the unmanaged hosting-only tier is the only one where the discount goes below £10/month. You can also host elsewhere for free since you own the code.
 
 [Full pricing details here](/prices/#content)
 

--- a/src/prices.md
+++ b/src/prices.md
@@ -36,14 +36,14 @@ You always have the option to host elsewhere since you own the full source code.
 
 ## Basic hosting (unmanaged sites)
 
-If you update your site rarely, or prefer to handle changes yourself, this lighter package is **£10** per month (this is my minimum - the discount doesn't go below £10):
+If you update your site rarely, or prefer to handle changes yourself, this lighter package is **£10** per month, or **£5** per month if discounted (this hosting-only package is the only place the discount goes below £10):
 
 - **Your site stays online** - hosted and backed up
 - **Bugs get fixed** - if something breaks, I sort it out
 
 You won't get personal marketing support or free content changes - but you can edit your site yourself, use my [free marketing guides](/guides/) and [videos](/videos/), or pay me or my brother Kevin at [KevinBurkeServices.com](https://kevinburkeservices.com) for content changes as needed.
 
-If £10/month is too much, you own the code - host it yourself for free on [Cloudflare Pages](https://pages.cloudflare.com/), [Netlify](https://netlify.com), or [GitHub Pages](https://pages.github.com/), and I'll help you get set up.
+If you'd rather not pay me anything, you own the code - host it yourself for free on [Cloudflare Pages](https://pages.cloudflare.com/), [Netlify](https://netlify.com), or [GitHub Pages](https://pages.github.com/), and I'll help you get set up.
 
 ## Managed hosting (web applications)
 

--- a/src/prices.md
+++ b/src/prices.md
@@ -36,12 +36,14 @@ You always have the option to host elsewhere since you own the full source code.
 
 ## Basic hosting (unmanaged sites)
 
-If you update your site rarely, or prefer to handle changes yourself, this lighter package is **£10** per month or **£5** if discounted:
+If you update your site rarely, or prefer to handle changes yourself, this lighter package is **£10** per month (this is my minimum - the discount doesn't go below £10):
 
 - **Your site stays online** - hosted and backed up
 - **Bugs get fixed** - if something breaks, I sort it out
 
 You won't get personal marketing support or free content changes - but you can edit your site yourself, use my [free marketing guides](/guides/) and [videos](/videos/), or pay me or my brother Kevin at [KevinBurkeServices.com](https://kevinburkeservices.com) for content changes as needed.
+
+If £10/month is too much, you own the code - host it yourself for free on [Cloudflare Pages](https://pages.cloudflare.com/), [Netlify](https://netlify.com), or [GitHub Pages](https://pages.github.com/), and I'll help you get set up.
 
 ## Managed hosting (web applications)
 

--- a/src/services.md
+++ b/src/services.md
@@ -16,7 +16,7 @@ Whether you need a [new website](/services/static-websites/#content), a [custom 
 
 **Transparent pricing:** I charge a [flat hourly rate](/prices/) for all jobs, with a clear breakdown of what each hour covers. No hidden fees, no surprise invoices.
 
-**Fast sites, low running costs:** I build websites that load quickly on any device, giving you a strong technical foundation for search and keeping your hosting costs low - I can host typical brochure sites for **£10/month** without support included, or you can host them elsewhere (often for free) since you own all the code. See my [prices page](/prices/#content) for managed hosting options that include ongoing support.
+**Fast sites, low running costs:** I build websites that load quickly on any device, giving you a strong technical foundation for search and keeping your hosting costs low - I can host typical brochure sites for **£10/month** (or **£5/month** for charities and other discounted groups) without support included, or you can host them elsewhere (often for free) since you own all the code. See my [prices page](/prices/#content) for managed hosting options that include ongoing support.
 
 **Works for everyone:** I build sites that are easy to use on phones, tablets, and desktops, and accessible to visitors with visual impairments.
 

--- a/src/services.md
+++ b/src/services.md
@@ -16,7 +16,7 @@ Whether you need a [new website](/services/static-websites/#content), a [custom 
 
 **Transparent pricing:** I charge a [flat hourly rate](/prices/) for all jobs, with a clear breakdown of what each hour covers. No hidden fees, no surprise invoices.
 
-**Fast sites, low running costs:** I build websites that load quickly on any device, giving you a strong technical foundation for search and keeping your hosting costs low - I can host typical brochure sites for **£10/month** (or **£5/month** for charities and other discounted groups) without support included. See my [prices page](/prices/#content) for managed hosting options that include ongoing support.
+**Fast sites, low running costs:** I build websites that load quickly on any device, giving you a strong technical foundation for search and keeping your hosting costs low - I can host typical brochure sites for **£10/month** without support included, or you can host them elsewhere (often for free) since you own all the code. See my [prices page](/prices/#content) for managed hosting options that include ongoing support.
 
 **Works for everyone:** I build sites that are easy to use on phones, tablets, and desktops, and accessible to visitors with visual impairments.
 

--- a/src/services/static-websites.md
+++ b/src/services/static-websites.md
@@ -4,7 +4,7 @@ meta_title: Fast, Affordable Websites | Prestwich, Manchester | Chobble
 description: Websites that load quickly, cost very little to host, and that you can edit yourself.
 snippet: Fast, affordable websites you can edit yourself
 order: -1
-meta_description: Fast websites that load in under a second, hosted from £10/month without support (or host elsewhere), and that you fully own - easy to edit yourself - Prestwich developer - 50% off for charities and artists
+meta_description: Fast websites that load in under a second, hosted from £10/month (£5 for charities) without support, and that you fully own - easy to edit yourself - Prestwich developer - 50% off for charities and artists
 ---
 
 # Fast, affordable websites you own
@@ -13,7 +13,7 @@ meta_description: Fast websites that load in under a second, hosted from £10/mo
 
 Platforms like WordPress, Wix, and Squarespace are designed to do everything, but most businesses only need a fraction of what they offer. The result? Websites that are slow to load, expensive to host, and hard to leave when you want to.
 
-I take a different approach. I build clean, fast, mobile-friendly websites tailored to your business. Because they're built efficiently, they **load fast** (pages feel instant once you're browsing, thanks to background preloading), **cost very little to host** (I can host typical small brochure sites for **£10/month** with no support included, or you can host elsewhere - often for free - since you own all the code; see my [prices page](/prices/#content) for managed hosting with support), and **you own all the code** - so you're never locked in.
+I take a different approach. I build clean, fast, mobile-friendly websites tailored to your business. Because they're built efficiently, they **load fast** (pages feel instant once you're browsing, thanks to background preloading), **cost very little to host** (I can host typical small brochure sites for **£10/month**, or **£5/month** for charities and other discounted groups - no support included; or you can host elsewhere, often for free, since you own all the code; see my [prices page](/prices/#content) for managed hosting with support), and **you own all the code** - so you're never locked in.
 
 You don't need to be technical. If you can edit a document, you can update your site.
 

--- a/src/services/static-websites.md
+++ b/src/services/static-websites.md
@@ -4,7 +4,7 @@ meta_title: Fast, Affordable Websites | Prestwich, Manchester | Chobble
 description: Websites that load quickly, cost very little to host, and that you can edit yourself.
 snippet: Fast, affordable websites you can edit yourself
 order: -1
-meta_description: Fast websites that load in under a second, hosted from £10/month (£5 for charities) without support, and that you fully own - easy to edit yourself - Prestwich developer - 50% off for charities and artists
+meta_description: Fast websites that load in under a second, hosted from £10/month without support (or host elsewhere), and that you fully own - easy to edit yourself - Prestwich developer - 50% off for charities and artists
 ---
 
 # Fast, affordable websites you own
@@ -13,7 +13,7 @@ meta_description: Fast websites that load in under a second, hosted from £10/mo
 
 Platforms like WordPress, Wix, and Squarespace are designed to do everything, but most businesses only need a fraction of what they offer. The result? Websites that are slow to load, expensive to host, and hard to leave when you want to.
 
-I take a different approach. I build clean, fast, mobile-friendly websites tailored to your business. Because they're built efficiently, they **load fast** (pages feel instant once you're browsing, thanks to background preloading), **cost very little to host** (I can host typical small brochure sites for **£10/month**, or **£5/month** for charities and other discounted groups - no support included; see my [prices page](/prices/#content) for managed hosting with support), and **you own all the code** - so you're never locked in.
+I take a different approach. I build clean, fast, mobile-friendly websites tailored to your business. Because they're built efficiently, they **load fast** (pages feel instant once you're browsing, thanks to background preloading), **cost very little to host** (I can host typical small brochure sites for **£10/month** with no support included, or you can host elsewhere - often for free - since you own all the code; see my [prices page](/prices/#content) for managed hosting with support), and **you own all the code** - so you're never locked in.
 
 You don't need to be technical. If you can edit a document, you can update your site.
 


### PR DESCRIPTION
## Summary
- Removes claims of £5/month hosting (for charities, musicians, and other discounted groups) - £10/month is now the minimum I'll charge for hosting
- Where the £5 claim was removed, replaced with a note that customers wanting cheaper options can host elsewhere (often free) since they own the code
- Files updated: `src/services.md`, `src/services/static-websites.md` (incl. meta description), `src/prices.md`, `src/examples/uke-group-north.md`

The remaining `£5/month` mentions in `src/prices.md`, `src/services/software-developer.md`, and `src/services/ruby-on-rails-developer.md` refer to third-party VPS server costs that the customer pays directly - my fee on top is £60/month, well above the £10 minimum, so those were left alone.

## Test plan
- [x] `npm run build` succeeds
- [ ] Spot-check rendered `/services/`, `/services/static-websites/`, `/prices/`, and `/examples/uke-group-north/` pages to confirm wording reads naturally

---
_Generated by [Claude Code](https://claude.ai/code/session_011pDR2EkCwZpkmmtHu4nBDY)_