### PR TITLE
Remove emojis from headings

### DIFF
--- a/src/services/technical-advice.md
+++ b/src/services/technical-advice.md
@@ -17,7 +17,7 @@ I give practical advice in plain English without pushing you toward expensive so
 
 <div class="card margins">
 
-### 💻 Website & hosting advice
+### Website & hosting advice
 
 I can help you understand your options and make smart choices about:
 
@@ -31,7 +31,7 @@ I can help you understand your options and make smart choices about:
 
 <div class="card margins">
 
-### 🔧 Technical support & strategy
+### Technical support & strategy
 
 Beyond websites, I can assist with:
 
@@ -45,7 +45,7 @@ Beyond websites, I can assist with:
 
 <div class="card margins">
 
-### ✅ Recent success stories
+### Recent success stories
 
 My advice has helped clients:
 


### PR DESCRIPTION
## Summary

Removes the three emoji characters from `###` headings in `src/services/technical-advice.md`:

- 💻 Website & hosting advice
- 🔧 Technical support & strategy
- ✅ Recent success stories

A repo-wide scan (markdown, HTML, Nunjucks, Liquid) confirmed these were the only emoji-prefixed headings.

## Test plan

- [ ] Build the site and confirm the Technical Advice page renders the three section headings without the leading icons.

---
_Generated by [Claude Code](https://claude.ai/code/session_019diUNxo1iFQm3P6AJqrmne)_