### PR TITLE
Humanise Eleventy developer page copy

### DIFF
--- a/src/services/eleventy-developer.md
+++ b/src/services/eleventy-developer.md
@@ -94,6 +94,14 @@ I build Eleventy sites with a focus on quality and sustainability:
 
 I write semantic HTML with minimal, efficient CSS so sites load fast even on slow connections and work properly with screen readers. Everything's progressive-enhancement first - your site works without JavaScript, and any JS layer just makes things nicer when it's there. The code I hand over is something you can read and edit yourself without needing a CS degree, and every project comes with documentation explaining how the pieces fit together. You're free to maintain it yourself or take it to another developer at any point.
 
+## Block-based pages with PagesCMS
+
+A lot of small business sites end up looking like one long wall of text, because the editing tools don't make anything else easy. The [Chobble Template](/services/chobble-template/) gets around this by giving every page a library of around thirty pre-styled blocks you can drop in and rearrange - hero banners, two-column rows that pair text with an image, video, code sample or callout, feature grids, image card grids, stats, galleries, marquees of partner logos, full-bleed video and image backgrounds, calls to action, embedded products, contact forms, and so on. There's a [full reference of every block](https://github.com/chobbledotcom/chobble-template/blob/main/BLOCKS_LAYOUT.md) on the template repo if you want to see the lot.
+
+The block system plugs straight into [PagesCMS](https://pagescms.org/), so editing a page means adding, reordering and tweaking blocks in a normal web form - no Markdown, no YAML, no code. You can build a page that opens with a hero, drops into a two-column intro with a photo, lists three things you offer as feature cards, breaks up to a full-width video background with overlay text, and finishes with a contact form, without anyone going near the source files.
+
+Because the blocks share consistent spacing, dark-mode support, scroll-reveal animations and responsive layouts, pages can look properly varied without ever looking inconsistent. And if a client needs something the existing blocks don't cover, I can add a new one without disturbing the rest of the system.
+
 ## Prices for Eleventy development
 
 As with all of my services, I charge a [flat hourly rate](/prices/) for Eleventy development with transparent estimates and regular updates. I've built a [price calculator](/price-calculator/) which you can use to get an immediate estimate for your Eleventy site build.

--- a/src/services/eleventy-developer.md
+++ b/src/services/eleventy-developer.md
@@ -82,7 +82,7 @@ I've converted a bunch of sites from Jekyll to Eleventy - some examples are [But
 
 ## Why Eleventy?
 
-I've used a bunch of static site generators and CMS platforms over the years and Eleventy is the one I keep coming back to for small business sites. It's JavaScript, which most developers can already work with - so if I get hit by a bus, you're not stuck looking for someone who knows an obscure templating language. And `npm` is a much less painful package manager to deal with than, say, Ruby gems.
+I've used a bunch of static site generators and CMS platforms over the years and Eleventy is the one I keep coming back to for small business sites. It's JavaScript, which most developers can already work with - so if I get hit by a bus, you're not stuck looking for someone who knows an obscure templating language. I run mine on [Bun](https://bun.sh/), which is faster and nicer to live with than npm, never mind something like Ruby gems.
 
 It's also flexible enough that I can build whatever a client actually needs without fighting the tool. Content can live in Markdown, JSON, HTML, or come from an API - whatever fits. Most small business sites are basically brochures that rarely change, so they don't need a database and a login screen, they need to load fast and be cheap to keep online. Eleventy is great for that. My [Chobble Template](/services/chobble-template/) even handles product listings and Stripe checkouts for shops that don't need live stock tracking.
 

--- a/src/services/eleventy-developer.md
+++ b/src/services/eleventy-developer.md
@@ -26,13 +26,11 @@ If you need something beyond a website - like a booking system or customer datab
 
 ### Building new Eleventy sites
 
-I'll create a **custom Eleventy site** around your specific business needs.
+I'll build you a custom Eleventy site shaped around what your business actually does.
 
-Your site will have a **fast, mobile friendly design** with minimal CSS and JavaScript, making the most of modern browser features. It will have **automatically optimised images** (with my [custom image placeholder](https://blog.chobble.com/blog/25-04-16-adding-base64-image-backgrounds-to-eleventy-img/) script too).
+Sites I build are mobile-friendly, lean on the CSS and JavaScript, and use my [custom image placeholder script](https://blog.chobble.com/blog/25-04-16-adding-base64-image-backgrounds-to-eleventy-img/) so images load nicely on slow connections. RSS feeds, sitemaps and the usual SEO bits (canonical tags, meta descriptions and so on) come baked in.
 
-**Pretty RSS feeds** encourage subscribers, **sitemaps** increase page discoverability, and **built-in SEO features** like canonical and meta tags will help your site perform well with search engines.
-
-The sites have **easy-to-update content** using plain text files or a simple CMS. **Default collections** like pages, news posts, products and galleries are configured, ready for you to edit. Sites have **secure contact forms** with automatic bot protection. You'll get the **full source code** with **clear documentation** to explain how everything works.
+You can edit content as plain Markdown files or through a simple CMS - whichever you're more comfortable with. Default collections like pages, news posts, products and galleries are pre-configured, ready to edit. There's a contact form with bot protection. You get the full source code and documentation explaining how it all fits together.
 
 Whether you're starting from a template like my [Chobble Template](/services/chobble-template/) or need something built from scratch, I'll deliver a website that's very easy to maintain and always loads quickly.
 
@@ -46,9 +44,9 @@ Whether you're starting from a template like my [Chobble Template](/services/cho
 
 If you've already got an Eleventy site (awesome, nice choice!) then I can help improve it.
 
-I can implement **new layouts and collections** to expand your site's capabilities. Your site could showcase products with **fast image galleries** and product showcases that load quickly. I could create **custom shortcodes** for special content blocks that make updating content easier. Need a blog? I can set up **complete blog functionality** with tags and categories for organizing your content. I can integrate **third-party services** like payment processors, booking systems, NPM packages, and more. Your site might benefit from **improved performance** and search engine visibility through technical optimisations. I can add **interactive elements** with vanilla JavaScript that enhance user experience without slowing down your site.
+I can add new layouts and collections, build out fast image galleries, write custom shortcodes for tricky content blocks, set up a blog with tags and categories, or wire in third-party stuff like Stripe or booking systems. If your site has gotten slow I can dig in and fix it, or add little bits of vanilla JavaScript for interactivity without dragging in a whole framework.
 
-Whatever you need building, my changes will fit right into your existing codebase without hurting Eleventy's excellent performance.
+Whatever the job, I'll fit the changes into your existing codebase without hurting Eleventy's performance.
 
 **Fill in the form below to discuss upgrading your existing website**
 
@@ -60,7 +58,9 @@ Whatever you need building, my changes will fit right into your existing codebas
 
 If you're stuck with an expensive, confusing, bulky or slow CMS website, I can help you migrate to Eleventy.
 
-I can **transform your WordPress, Wix, Squarespace** or other sites into a tidy and minimalist Eleventy site. Your site will **keep its existing design** and content while improving performance. I'll set up **simple editing tools** that match your technical comfort level. You'll **reduce or eliminate ongoing hosting costs** by moving to more affordable static hosting options. Your site will **keep all the features you love** without the bloat you don't need.
+I've moved sites off WordPress, Wix, Squarespace and a handful of other CMSes onto Eleventy. The usual goal is to keep the design and content people are already happy with, drop the bits causing pain, and end up with something that loads faster, costs less to host, and is easier to edit.
+
+I'll match the editing setup to how technical you actually are - some clients are happy editing Markdown directly, others want a small CMS sitting on top. Either is fine.
 
 **A real example:** I recently converted [A&S Home Furnishings](/examples/as-home-furnishings) from an expensive, broken CMS to a streamlined Eleventy site. I used `wget` to archive the existing site, converted the pages to Markdown with `pandoc`, and implemented a fresh, responsive design with minimal CSS. The new site loads instantly, has a working contact form, and costs just £10/month to host.
 
@@ -82,31 +82,17 @@ I've converted a bunch of sites from Jekyll to Eleventy - some examples are [But
 
 ## Why Eleventy?
 
-I've used a bunch of static site generators and CMS platforms over my years nerding, and have settled on Eleventy for small business websites, for a few reasons:
+I've used a bunch of static site generators and CMS platforms over the years and Eleventy is the one I keep coming back to for small business sites. It's JavaScript, which most developers can already work with - so if I get hit by a bus, you're not stuck looking for someone who knows an obscure templating language. And `npm` is a much less painful package manager to deal with than, say, Ruby gems.
 
-**JavaScript-based and beginner-friendly.** Eleventy uses JavaScript, which is easier for beginners to understand than other programming languages. This means more autonomy over your website - if I get hit by a bus, you'll find it easier to maintain or modify your site yourself or find another developer.
+It's also flexible enough that I can build whatever a client actually needs without fighting the tool. Content can live in Markdown, JSON, HTML, or come from an API - whatever fits. Most small business sites are basically brochures that rarely change, so they don't need a database and a login screen, they need to load fast and be cheap to keep online. Eleventy is great for that. My [Chobble Template](/services/chobble-template/) even handles product listings and Stripe checkouts for shops that don't need live stock tracking.
 
-**NPM package management.** Eleventy uses `npm`, a fast and reliable package manager that's easier to run than alternatives like Ruby gems, making development and maintenance simpler.
-
-**Highly extensible.** I can build custom transforms, collections, or use different formats for layouts to perfectly match your business needs. This flexibility allows your site to grow with your business.
-
-**Perfect for most small businesses.** Most small business websites are essentially glorified brochures that rarely change, which static site generators are perfect for. My [Chobble Template](/services/chobble-template/) even supports product listings and Stripe checkouts, for sites that don't need live stock tracking.
-
-**Flexible content management.** You can store your content in Markdown, JSON, HTML, or it can even be automatically generated from an API - whatever works best for your business.
-
-**Future-proof technology.** Eleventy outputs standard web code that will continue to work for decades, unlike proprietary platforms that might change prices, remove features, or disappear.
-
-**Affordable hosting options.** Static sites can be hosted for free or very cheaply on services like Bunny.net, Netlify, or Cloudflare Pages.
-
-**Excellent SEO potential.** Fast-loading, semantically structured pages rank better in search results. Check out my [SEO guides](/guides/) for strategies to maximize this potential.
+The output is plain static HTML, which means it'll keep working for as long as browsers exist, it ranks well because it loads fast, and it can be hosted for free or close to it on Bunny.net, Netlify or Cloudflare Pages. (See my [SEO guides](/guides/) for more on the search side.)
 
 ## My Eleventy approach
 
 I build Eleventy sites with a focus on quality and sustainability:
 
-I create sites with **semantic HTML** that's accessible and SEO-friendly from the ground up. Your site will use **minimal, efficient CSS** for fast loading times even on slower connections. I implement **progressive enhancement** so your site works for everyone, regardless of their device or browser. You'll receive **maintainable code** you can understand and update without needing a computer science degree. Every project includes **clear documentation** of how everything works so you're never left wondering.
-
-Each site I build comes with full source code access and guidance on how to maintain and update your site yourself if you choose to.
+I write semantic HTML with minimal, efficient CSS so sites load fast even on slow connections and work properly with screen readers. Everything's progressive-enhancement first - your site works without JavaScript, and any JS layer just makes things nicer when it's there. The code I hand over is something you can read and edit yourself without needing a CS degree, and every project comes with documentation explaining how the pieces fit together. You're free to maintain it yourself or take it to another developer at any point.
 
 ## Prices for Eleventy development
 
@@ -116,9 +102,9 @@ As with all of my services, I charge a [flat hourly rate](/prices/) for Eleventy
 
 Want to take control of your own Eleventy site? I offer [technical training and tutoring](/services/technical-advice/) to help you master Eleventy:
 
-You'll **understand the basics** of Eleventy's template system and how it generates your site. I'll teach you to **create and edit content** using Markdown so you can update your site yourself. You'll learn how to **add new pages and sections** to expand your site as your business grows. We'll cover how to **customize designs and layouts** to match your evolving brand identity. You'll become confident in **deploying updates** to your hosting provider without needing technical support.
+We'll cover the basics of how Eleventy turns your files into a website, writing and editing content in Markdown, adding new pages and sections as the business grows, tweaking the design and layout, and deploying updates yourself without needing to call me.
 
-Training sessions can be conducted in person (if you're in Prestwich) or remotely, and are tailored to your current knowledge level and learning goals.
+Sessions can be done in person if you're in Prestwich, or remotely, and we'll work from wherever you are now rather than a fixed curriculum.
 
 ## Let's build something fast
 


### PR DESCRIPTION
## Summary

Strips the bold-bullet feature-list patterns from `src/services/eleventy-developer.md` and rewrites them as plain prose in Stef's voice (matching `about/stef.md` and `wordpress-developer.md`).

Sections rewritten:
- **Building new Eleventy sites** body — three paragraphs of bold-prefixed feature phrases collapsed into prose.
- **Adding features** — the seven-feature bingo paragraph at line 49 condensed to a comma-separated list, per the suggested rewrite.
- **Converting CMS sites** — the "keep all the features you love without the bloat" tagline paragraph rewritten as two plain paragraphs.
- **Why Eleventy?** — eight bold title-case bullets reduced to three paragraphs covering the reasons that actually matter (familiarity of JS, flexibility, plain-HTML output / cheap hosting).
- **My Eleventy approach** — bold-peppered paragraph smoothed into prose; merged with the redundant follow-up about source code access.
- **Learn Eleventy yourself** — bold-bingo training list rewritten as plain prose; merged with the redundant follow-up about tailoring to knowledge level.

## Test plan

- [ ] Read the page top-to-bottom and confirm it reads as a single human voice
- [ ] Check that nothing on the page references content that was removed (in-page anchor links still resolve)
- [ ] Build the site locally and confirm no Markdown rendering issues

https://claude.ai/code/session_011BpThQifx8fZLFpVH5Lwz2

---
_Generated by [Claude Code](https://claude.ai/code/session_011BpThQifx8fZLFpVH5Lwz2)_