### PR TITLE
Remove AI tics from keywords guide

### DIFF
--- a/src/guides/keywords-and-keyword-stuffing.md
+++ b/src/guides/keywords-and-keyword-stuffing.md
@@ -7,7 +7,7 @@ meta_description: Guide to using keywords effectively - understand search terms,
 
 # Keywords & keyword stuffing
 
-The whole point of your website is to attract customers – but how do search engines decide who finds you? This guide should demystify "keywords" while helping you avoid "keyword stuffing", an outdated and ineffective tactic.
+The whole point of your website is to attract customers - but how do search engines decide who finds you? This guide is about how "keywords" work, and how to avoid "keyword stuffing", which is an outdated and ineffective tactic.
 
 **Rather watch a video on this topic? [Click here to watch it](/videos/keywords-and-keyword-stuffing/).**
 
@@ -17,7 +17,7 @@ The whole point of your website is to attract customers – but how do search en
 
 ## 1. What are keywords?
 
-Keywords are the words and phrases people type into search engines like Google when they're looking for a product, service, or answer. Think of them as "search shortcuts" that connect what your customers need to what your business offers.
+Keywords are the words and phrases people type into search engines like Google when they're looking for a product, service, or answer. They're basically the link between what people are trying to find and what your business is offering.
 
 Potential customers of my widget hire company might search for things like:
 
@@ -28,36 +28,36 @@ Potential customers of my widget hire company might search for things like:
 
 ### Why keywords matter
 
-- **For search engines**: Keywords help people find you quickly. If your website uses the terms _they_ use, search engines are more likely to show you when they search for those words.
-- **For visitors**: Visitors to your site who read your content will see that it addresses the term they searched for, making them more likely to contact you.
+- **For search engines**: if your website uses the same words your potential customers are typing into Google, you're more likely to show up when they search.
+- **For visitors**: when someone lands on your page and sees the words they searched for, they'll feel like they've found the right place, and they're more likely to get in touch.
 
 ---
 
 ## 2. What is "keyword stuffing"?
 
-Keyword stuffing is the outdated practice of cramming your content with excessive or unnatural keywords to trick search engines. For example, writing _"Looking for widget hire in Manchester? Our Manchester widget hire services offer cheap widget hire deals across Manchester"_. Repeating terms like _"widget hire"_ not only frustrates readers but signals to Google that your content is spammy, which risks penalising your site in search results - and even if you're not penalised, this content isn't helping you.
+Keyword stuffing is the old practice of cramming your content full of keywords, trying to trick search engines into ranking you higher. An example would be writing something like _"Looking for widget hire in Manchester? Our Manchester widget hire services offer cheap widget hire deals across Manchester"_. Repeating _"widget hire"_ over and over doesn't just annoy your readers, it also signals to Google that your content is spammy, which risks getting your site penalised - and even if you don't get penalised, the content isn't doing you any favours either.
 
 [Google lists "Keyword stuffing" as a type of spam on their "Spam policies" page](https://developers.google.com/search/docs/essentials/spam-policies) and says _"to be eligble to appear in Google web search results, content shouldn't violate Google Search's overall policies or the spam policies listed on this page"_.
 
-In the past, SEO strategies revolved around _"keyword density"_, a formula dictating how often a keyword should appear on a page. Today, this approach backfires. Google's algorithms prioritize **useful content** over robotic repetition. Instead of tallying keywords, they assess:
+SEO strategies used to revolve around _"keyword density"_, a formula for how often a keyword should appear on a page. These days that approach backfires - Google's algorithms care about whether your content is useful, not how many times you've crammed the keyword in. Instead of counting keywords, they look at things like:
 
-1. **Topic Depth**: Does your page answer all questions a customer might have? A widget hire page should cover pricing, delivery areas, FAQs, and use cases, not just repeat _"widget hire"_.
-2. **Natural Flow**: Does the content sound human? Compare _"Our widget hire services in Prestwich offer Manchester widget hire at widget hire rates"_ (awkward) with _"We provide same-day widget delivery across Manchester, including Prestwich and Whitefield."_
-3. **User Engagement**: If visitors "bounce" back to search results quickly, Google measures this and assumes your content doesn't meet their needs. Keyword-stuffed pages often fail to hold attention because they prioritize SEO jargon over clear answers.
+1. **Whether your page actually covers the topic**: does it answer the questions a customer might have? A widget hire page should cover pricing, delivery areas, FAQs, and what people use them for, not just repeat _"widget hire"_ over and over.
+2. **Whether it reads naturally**: does it sound like a human wrote it? Compare _"Our widget hire services in Prestwich offer Manchester widget hire at widget hire rates"_ (awkward) with _"We provide same-day widget delivery across Manchester, including Prestwich and Whitefield."_
+3. **Whether visitors stick around**: if people "bounce" back to search results quickly, Google takes that as a sign your page didn't meet their needs. Keyword-stuffed pages often fail to hold attention because they're more interested in SEO jargon than in actually answering the question.
 
 **How to avoid stuffing**:
 
-- Replace overused terms with synonyms (_"widgets for parties"_, _"widget delivery company"_, _"widgeteer"_, instead of _"widget hire"_ over and over).
-- Use local phrases naturally: _"serving North Manchester"_ vs. _"Manchester widget hire Manchester"_.
-- Read sentences aloud. If they sound forced, simplify! For instance, _"Affordable rates for weekend events"_ is clearer than _"Widget hire Manchester affordable widget hire for events."_
+- Mix in synonyms (_"widgets for parties"_, _"widget delivery company"_, _"widgeteer"_) instead of repeating _"widget hire"_ over and over.
+- Use local phrases naturally: _"serving North Manchester"_ rather than _"Manchester widget hire Manchester"_.
+- Read sentences aloud. If they sound forced, simplify them. _"Affordable rates for weekend events"_ is clearer than _"Widget hire Manchester affordable widget hire for events."_
 
-By focusing on **user intent** and **natural language**, you align with modern SEO best practices and keep customers engaged.
+If you focus on what people are actually searching for and write in plain English, you'll do well on modern search engines and keep your visitors interested at the same time.
 
 ---
 
 ## 3. User intent: What are potential customers really searching for?
 
-User intent means _what your customers want_ when they type a search into Google. It's not just about the words they use – it's about the goal behind their search. Get this right, and your website becomes the answer they're looking for. Get it wrong, and you'll attract clicks that go nowhere.
+User intent means _what your customers actually want_ when they type a search into Google. It's not just about the words they use, it's about what they're trying to do or find out. If your page matches that, you'll get the right kind of visitors. If it doesn't, you'll attract clicks from people who'll just hit the back button.
 
 **Interested in targeting specific, longer search phrases? [Click here to watch my video on long tail keywords](/videos/long-tail-keywords/).**
 
@@ -79,14 +79,14 @@ There are three main types of searches:
 
 **Example for your business**:
 
-If you notice your customers frequently ask, _"Do you deliver to events on weekends?"_, their intent isn't just to find a widget hire company – it's to confirm logistics. Your content should answer this directly:
+If you notice your customers regularly ask _"Do you deliver to events on weekends?"_, their intent isn't just to find a widget hire company - it's to check whether you can actually do what they need. Your content should answer that directly:
 
 > _"We offer weekend delivery for events across Manchester, including Prestwich and Whitefield. Book by 3pm for next-day service."_
 
-**How to Find User Intent**:
+**How to find user intent**:
 
-- **Google's "People Also Ask"**: Type your keyword (e.g., _"widget hire Manchester"_) into Google. The drop-down questions (e.g., _"How long can I hire widgets for?"_) reveal related intents.
-- **Listen to your customers**: What questions do they ask? (e.g., _"Are deposits refundable?"_)
+- **Google's "People Also Ask"**: type your keyword (e.g. _"widget hire Manchester"_) into Google. The drop-down questions (like _"How long can I hire widgets for?"_) tell you what else people are wondering about.
+- **Listen to your customers**: what questions do they actually ask you? (e.g. _"Are deposits refundable?"_)
 
 ---
 
@@ -94,8 +94,8 @@ If you notice your customers frequently ask, _"Do you deliver to events on weeke
 
 Semantically related words are phrases or terms that _connect_ to your main keyword, either as synonyms (like "dongles" for widgets) or contextually linked ideas (like "event supplies" or "party equipment").
 
-- **Search engines** use them to understand context. If your page mentions "widget hire", "dongle repairs", and "wotzit storage", Google knows your business covers the full lifecycle of these products.
-- **Visitors** get a clearer picture of your services without its text feeling repetitive.
+- **Search engines** use them to work out context. If your page mentions "widget hire", "dongle repairs", and "wotzit storage", Google knows your business covers the whole lifecycle of these products.
+- **Visitors** get a clearer picture of your services, without the text feeling repetitive.
 
 So, instead of repeating _"widget hire in Manchester"_ ten times, try:
 
@@ -112,59 +112,57 @@ So, instead of repeating _"widget hire in Manchester"_ ten times, try:
 
 ## 5. Headers (H1, H2, H3 tags)
 
-Headers act like signposts for both visitors and search engines. Just like chapter titles in a book, they break up walls of text, making it easier for visitors to scan your content and understand what each section covers. Your H1 tag is your **main page title** – every page should have just one. Think of it as the bold headline on a shop front. A vague H1 like _"Services"_ doesn't say much, but _"Affordable Widget Hire in Prestwich & Manchester"_ instantly tells Google and visitors exactly what you offer.
+Headers are signposts on your page, similar to chapter titles in a book - they break up the text into sections so visitors can scan and find what they want. Your H1 tag is the main page title, and every page should have exactly one. A vague H1 like _"Services"_ doesn't tell anyone much, but _"Affordable Widget Hire in Prestwich & Manchester"_ instantly tells both Google and your visitors what the page is about.
 
-H2 tags split your content into clear sections. For example, _"Why Choose Our Whitefield Doodah Hire?"_ or _"Same-Day Widget Delivery in Manchester"_ keep the focus local without repeating "widget hire" endlessly. Switch "widget" for synonyms like _"dongle delivery"_ to keep things fresh. H3s dive deeper under those H2s, like adding _"Our Prestwich Hire Process in 3 Simple Steps"_ under a broader _"How Widget Hire Works"_ section.
+H2 tags split your content into clear sections. Something like _"Why Choose Our Whitefield Doodah Hire?"_ or _"Same-Day Widget Delivery in Manchester"_ keeps the focus local without repeating "widget hire" over and over. You can swap "widget" for synonyms like "dongle delivery" to keep things fresh. H3s sit under H2s for sub-topics, like _"Our Prestwich Hire Process in 3 Simple Steps"_ under a broader _"How Widget Hire Works"_ section.
 
-Honestly – most pages won't need H3s, unless they are really long. Don't force them in just for SEO's sake.
+Honestly, most pages won't need H3s unless they're really long. Don't force them in just for SEO's sake.
 
-**Check before saving**: Do your headers guide readers naturally? Have you woven in locations like Prestwich? Is the language human-friendly or stuffed with jargon?
-
----
-
-### 6. Meta descriptions – your site's "shop window" in search results
-
-A meta description is the short blurb that appears under your website link in search engine results. Think of it as your **digital shop window** – a split-second chance to convince searchers to click your link over rivals. While Google might replace yours with a more relevant page snippet if they think it matches the searcher's intent better, you still need to craft a compelling meta description. Why? Because if Google _does_ show yours, a clear, benefit-packed one can **boost your click-through rate even if you're not ranking first**.
-
-**Crucially**, your meta description must **answer the searcher's intent**. If someone types _"widget hire Prestwich"_, a vague _"We provide widgets. Contact us for more info"_ won't cut it. Instead, try: _"Need widget hire in Prestwich? We're local experts offering flexible hire, 24/7 support, and same-day delivery. Book online today!"_ – clear, keyword-aware, and action-focused.
-
-For formatting, **keep it under 150 characters** (use a [character counter](https://charactercounttool.com/) to check), and work in your keyword naturally once, like _"widget hire in Manchester"_. Mention a location (Prestwich, Whitefield, or Manchester) to attract locals and highlight benefits – urgency (_"same-day"_), ease (_"no deposit"_), or USPs like live booking.
-
-**Key dos and don'ts**: Focus on your strongest reason to choose you (e.g., _"serving Prestwich since 2020"_), include delivery areas, and avoid keyword spam (_"widget hire widget hire Manchester"_). Never reuse the same meta description across pages – each should reflect the page's unique focus.
-
-Your meta description is free advertising in search results. Make it impossible to scroll past!
+Before saving, give the page a read - do your headers guide readers naturally? Have you mentioned locations like Prestwich? Does it sound like a human wrote it, or is it stuffed with jargon?
 
 ---
 
-## 7. Images & "alt tags": describe, don't stuff
+### 6. Meta descriptions
 
-Alt text (alternative text) is a short, factual description of an image that serves two key purposes. First, it helps visually impaired users "see" the image via screen readers. Second, it tells search engines what the image shows, boosting your SEO. For example, a photo of widgets at a corporate event might have alt text like _"Red widgets displayed at a Manchester corporate event"_ – descriptive and location-specific. Avoid keyword-stuffed nonsense like _"Cheap widget hire Manchester widgets for hire"_ or generic filenames like _"IMG_1234.jpg"_, which hurt both accessibility and SEO.
+A meta description is the short blurb under your link in search results. Google often replaces it with whatever snippet matches the search better, but when they do show yours, a good one will get you more clicks even if you're not ranking first - so it's worth writing.
 
-Why bother? Over [43 million people](https://www.who.int/news-room/fact-sheets/detail/blindness-and-visual-impairment) worldwide have visual impairments, and clear alt text ensures your site works for everyone. Plus, Google uses alt text to rank images in **Google Images**, so a well-described photo of _"Technician repairing a doodah in Whitefield"_ could bring in local customers.
+Your meta description should answer what the searcher actually wants. If someone types _"widget hire Prestwich"_, a vague _"We provide widgets. Contact us for more info"_ won't cut it. Try something like: _"Need widget hire in Prestwich? We're local experts offering flexible hire, 24/7 support, and same-day delivery. Book online today!"_ - clear, focused on what the person wants, and tells them what to do next.
 
-When writing alt tags, **stick to the facts**. Describe what's in the image (_"Three blue widgets stacked at a Manchester park"_), not your opinion (_"Best widget hire in Manchester"_). Keep it short (under 125 characters) and include location or action details where relevant, like _"Heaton Park event setup with widgets"_ or _"Technician loading widgets into a van in Whitefield"_. Skip phrases like _"image of"_ – screen readers already announce it's an image. For decorative graphics (e.g., dividers), leave the alt text empty.
+Keep it under 150 characters (use a [character counter](https://charactercounttool.com/) to check), and work your main keyword in once - something like _"widget hire in Manchester"_. Mention a location to attract locals, and highlight what makes you stand out, whether that's _"same-day"_, _"no deposit"_, or anything else specific to you.
 
-**BCN customers**: Your product images already have solid alt tags matching their names – nice!
+A few things to keep in mind: focus on your strongest reason for someone to choose you (like _"serving Prestwich since 2020"_), include your delivery areas, and avoid keyword spam like _"widget hire widget hire Manchester"_. And don't reuse the same meta description across pages - each one should match its page.
 
-**Before saving**, ask yourself: Does this alt text literally describe the image? Is it free of keyword spam? Would it make sense if the image didn't load?
+---
+
+## 7. Images & "alt tags"
+
+Alt text (alternative text) is a short description of an image that does two jobs. First, it helps visually impaired users "see" the image via screen readers. Second, it tells search engines what the image shows, which is good for SEO. For example, a photo of widgets at a corporate event might have alt text like _"Red widgets displayed at a Manchester corporate event"_ - descriptive and location-specific. Avoid keyword-stuffed alt text like _"Cheap widget hire Manchester widgets for hire"_, or generic filenames like _"IMG_1234.jpg"_, which are bad for accessibility and SEO alike.
+
+It matters because over [43 million people](https://www.who.int/news-room/fact-sheets/detail/blindness-and-visual-impairment) worldwide have visual impairments, and clear alt text means your site works for them too. And Google uses alt text to rank images in **Google Images**, so a well-described photo of _"Technician repairing a doodah in Whitefield"_ could bring in local customers.
+
+When writing alt tags, just describe what's actually in the image, rather than giving your opinion. _"Three blue widgets stacked at a Manchester park"_ is good, _"Best widget hire in Manchester"_ is not. Keep it short (under 125 characters) and include location or action details where relevant, like _"Heaton Park event setup with widgets"_ or _"Technician loading widgets into a van in Whitefield"_. Skip phrases like _"image of"_ - screen readers already announce that it's an image. For decorative graphics like dividers, leave the alt text empty.
+
+**BCN customers**: your product images already have solid alt tags matching their names - nice!
+
+Before saving, give it a check - does this alt text actually describe the image? Is it free of keyword spam? Would it make sense if the image didn't load?
 
 ---
 
 ## 8. How to structure content effectively
 
-Writing for humans means explaining your services as if you're chatting with a customer. Skip the jargon like _"Widget hire solutions for Manchester-based event facilitations"_ – it's vague and reads weirdly. Instead, aim for clarity: _"Need widgets for your Manchester event? We deliver same-day, with flexible pricing and no hidden fees."_ See the difference? One feels like a corporate brochure; the other solves a real problem.
+Writing for humans means explaining your services like you're chatting with a customer. Skip the jargon - things like _"Widget hire solutions for Manchester-based event facilitations"_ are vague and read weirdly. _"Need widgets for your Manchester event? We deliver same-day, with flexible pricing and no hidden fees"_ is much clearer. The first one sounds like a corporate brochure, the second one actually answers the customer's question.
 
-Internal links act as signposts, guiding visitors to related parts of your site. For instance, if your blog post mentions the _"Top 5 Event Trends in Manchester"_, weave in a link like _"Need widgets for your event? Explore our Manchester Event Widget Hire Guide."_ Similarly, your homepage's product section could highlight _"One of our most popular hires: [blue widgets]."_
+Internal links help guide visitors to other parts of your site that might be useful to them. For instance, if you've got a blog post about the _"Top 5 Event Trends in Manchester"_, you could link to your event widget hire page from it: _"Need widgets for your event? Have a look at our Manchester Event Widget Hire Guide."_ Or your homepage's product section could mention _"One of our most popular hires: [blue widgets]."_
 
-**Keep it natural**: Use descriptive phrases like _"Book Whitefield widget delivery here"_ instead of generic "Click here." And only link where it makes sense – forcing links into unrelated text confuses readers and search engines alike.
+Keep the link text descriptive - something like _"Book Whitefield widget delivery here"_ rather than just _"click here"_. And only add links where they actually make sense - forcing them into unrelated text confuses both readers and search engines.
 
 ### Local SEO
 
-A smart way to boost local SEO is by **naming nearby landmarks** in your content. For example, saying you're "minutes from the Whitefield Metrolink station" or "serving events near Heaton Park" helps customers – and Google – link your services to specific areas. This matches real searches like _"widget hire near Heaton Park"_, putting you front-of-mind for local needs.
+A good way to boost local SEO is to **mention nearby landmarks** in your content. So if you say you're "minutes from the Whitefield Metrolink station" or "serving events near Heaton Park", that helps both customers and Google connect your business to those areas. It also matches real searches like _"widget hire near Heaton Park"_.
 
-For businesses covering multiple areas, **dedicated location pages** work wonders. Create a page titled _"Manchester Widget Hire for Events & Businesses"_ and another for _"Same-Day Widget Hire in Prestwich"_. These let you target location-specific searches without your pages competing for the same keywords. On each page, include an address map, local testimonials (like _"Stefan delivered really quickly to our Prestwich office!"_), and unique perks for that area, such as free overnight hires for Whitefield customers.
+For businesses covering multiple areas, **dedicated location pages** are really useful. You could have one called _"Manchester Widget Hire for Events & Businesses"_ and another for _"Same-Day Widget Hire in Prestwich"_, which means each page can target its own location-specific searches without competing with the others. On each one, include a map, local testimonials (like _"Stefan delivered really quickly to our Prestwich office!"_), and any perks specific to that area, such as free overnight hires for Whitefield customers.
 
-⚠️ **Important**: Never copy-paste the same content and just swap "Manchester" for "Prestwich"! Google penalises duplicate content, so keep each page fresh:
+**Important**: don't just copy-paste the same content and swap "Manchester" for "Prestwich". Google penalises duplicate content, so keep each page fresh:
 
 - Manchester Page: _"Our Manchester team offers [specific service] with [unique perk, e.g., weekend availability]."_
 - Prestwich Page: _"Serving Prestwich clients with [different perk, e.g., free same-day setup]."_


### PR DESCRIPTION
Rewrites the keywords & keyword stuffing guide in Stefan's plain, conversational voice (matching `why-bother.md` and `structuring-your-site.md`).

## Changes

- Drop the "shop window" / "split-second" / "rivals" / "benefit-packed" marketing-copy framing in the meta descriptions section
- Delete the "Make it impossible to scroll past!" closer
- Replace "Crucially", "robotic repetition", "dive deeper", "work wonders", "front-of-mind", "Get this right..." parallel structures, and similar AI tics
- Lowercase title-case AI-style bullet headings ("Topic Depth", "Natural Flow", "User Engagement", "How to Find User Intent")
- Drop the digital "shop window"/"shop front" metaphors and the warning emoji
- Switch decorative en-dashes for plain hyphens to match the rest of the guides
- Tighten the H1/H2/H3 section, the user-intent intro, the alt-text section, and the "structure content effectively" / local SEO sections
- Fix `prioritize` -> British English (now reworded)

The information and structure are unchanged - just the tone.

## Test plan

- [ ] Read the page end-to-end and check it sounds like Stefan
- [ ] Confirm the build still passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4JPadGokRAGSKmwabEsWv)_