### PR TITLE
Add CLAUDE.md voice guide for Stef

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,185 @@
+# Voice & Tone
+
+This site has a distinct voice: nerdy, principled, opinionated without being preachy, recognisably Manchester without dialect cosplay. It's how a 40-something Mancunian programmer who reads a lot, takes ethics seriously, and has strong opinions about Big Tech might write about his own work — not how a marketing agency would write it for him.
+
+This is a guide, not a template. Slavish application is what makes copy sound generated.
+
+## The trap to avoid
+
+Stef **writes**. He doesn't talk into a phone in the back of a van. The voice is comfortable with long sentences, sub-clauses, parentheticals, and meandering through an idea before getting to the point. That's the texture of someone explaining their work to a customer over a coffee, not delivering a sales pitch.
+
+The two failure modes:
+
+1. **Marketing copywriter polish.** Tight rhythm, short sentences, parallel structures, deflating one-liners. If a page reads like LinkedIn or a brochure, it's wrong. Lengthen the sentence, add a hedge, let the thought breathe.
+2. **Northern cosplay.** Stef finds fake Manchester dialect so embarrassing he wrote a whole section of his AI guide making fun of it — "Reet, let me tell thi abaat them Bolt Thrower lads … ..Gross." Do not sprinkle "owt" / "proper good" / "by 'eck" / phonetic spellings on top to signal authenticity. The Manchester-ness lives in **specifics** (Prestwich, Costa, Cuckoo, Goods In, the Manchester extreme metal scene, Blue Pits Housing Action) and a small handful of **honest informal phrases** ("a few quid", "have a bash"), not in spelling or accent.
+
+### The cuppa test
+
+Could Stef say this to a customer over a brew at Cuckoo, while explaining what he does? If the line sounds like it belongs on a billboard, take the polish off. If it sounds like a costume version of "Northerner", take that off too.
+
+## Source corpus
+
+Don't lean on any single voice — that becomes a tribute act. The shared DNA across these is what we're after: opinionated, principled, plain-spoken writing that doesn't reach for marketing flourish.
+
+- **Aaron Swartz** — short essays on Big Tech, openness, and ethics. Honest, principled, no posturing.
+- **Cory Doctorow** — anti-Big-Tech writing in plain English. Long sentences are fine; clarity is non-negotiable.
+- **Drew DeVault** and sr.ht blog posts — opinionated open-source maintainer voice.
+- **Maxine Peake** — *Jacobin* interview, BFI keynote. Working-class Manchester leftism, written down, no put-on.
+- **Caroline Aherne** — *The Royle Family* and *Mrs Merton* interviews. Manchester voice without dialect cosplay.
+- **John Cooper Clarke** — long-form Q&As. For looseness, specificity, and dry humour without punchline structure.
+- **Mark Fisher** — *Capitalist Realism*, *k-punk*. Plain leftist criticism that doesn't reach for the slogan.
+- **Owen Jones** columns — UK leftist working-class register; comfortable with politics on the page.
+- **Sleaford Mods** lyrics — anti-corporate venom without affectation. Not a model for sentence structure, a model for attitude.
+- **The Free Software Foundation / GNU manifestos** — tech idealism in plain prose.
+
+When stuck, don't generate — read one of these. The voice that emerges from this DNA is **nerdy, principled, opinionated, comfortable being one person with a point of view**.
+
+## Principles
+
+### 1. First person, comfortable being one person
+
+It's "I", not "we". "I run Chobble CIC from Prestwich", not "Chobble provides web development services". "I'll reply within 48 hours", not "We'll respond". Chobble is one bloke and the voice should reflect that — switching to "we" makes it sound like an agency, which Stef explicitly says he is not.
+
+> "I'm Stef. I run Chobble CIC from Prestwich, Manchester. I've been building websites for a living since the mid-2000s, and I care deeply about doing it honestly, transparently, and in a way that genuinely helps the people who hire me."
+
+### 2. Long sentences with hedges, asides, and parentheticals
+
+The voice is comfortable rambling through an idea, hedging, qualifying, and dropping in a parenthetical mid-thought. Multiple commas, "which" and "and so" connectives, an em-worth of caveat — fine. This is the opposite of marketing-copy rhythm and that's the point.
+
+> "I'm not opposed to certifications in principle, but I've met plenty of certified developers who were poor at the job and plenty of uncertified ones who were excellent. My results and history speak for themselves. If that's not enough for you, I'm probably not the right person, and that's fine."
+
+> "It's worth remembering that Google and Microsoft who own two of the biggest AI chatbots (Gemini and ChatGPT) also run their own search engines, so they have already compiled billions of existing websites."
+
+Don't break these up into punchy fragments. The voice gets its texture from looseness, not rhythm.
+
+### 3. Specifics over abstractions
+
+Prestwich, not "the local area". Costa, Cuckoo, Goods In, not "local cafés". Bandcamp, not "a previous employer". $200 million a year, not "a high-traffic site". 1,000+ customers, not "many". Blue Pits Housing Action and Vegan Prestwich by name, not "various charities". Napalm Death (and the fact that they're from Birmingham, not Manchester). The voice gets its credibility from being specific.
+
+> "I proposed and implemented the easter egg where paying £6.66 for an item shows the metal horns 🤘 (and £4.20 shows a tree 🌳, among others), helped on Bandcamp's carbon offsetting for company meet-ups, and I supported the unionisation efforts of my US colleagues."
+
+### 4. Plain words, mild informal Britishisms, no dialect spelling
+
+Vocabulary is plain English with a few informal touches when they fit naturally — "a few quid", "have a bash", "loads of", "a tonne of", "kinda", "a fair bit", "down the line". British spelling throughout ("colour", "organised", "favour"). Never "owt", "our kid", "champion" as adjective, or phonetic accent spelling. When Stef wants emphasis he reaches for "..Gross" or "Boo!", not "proper gross" or "dead bad".
+
+### 5. Direct opinions, owned as opinions
+
+Stef has views and states them — anarchism, vegan, anti-Big-Tech, anti-spam-marketing, sceptical of WordPress, sceptical of Adwords agencies. But he flags them as opinions, leaves room for the reader to disagree, and says he'll update if he's wrong.
+
+> "I'm an anarchist, which in practice means I don't believe in bosses, including myself as the boss of whoever's reading this. I publish my opinions as opinions, not as pronouncements. If I'm wrong about something, tell me and I'll update."
+
+> "Personally, I don't trust any Facebook stats about engagement, or views, or advert clicks, or anything else."
+
+Opinionated, not preachy. The voice never moralises at the reader, but it doesn't pretend to be neutral either.
+
+### 6. Nerd enthusiasm, owned, not hidden
+
+Stef calls himself a "full-time nerd" and means it. The voice happily gets into the technical detail — Deno on the edge, esbuild, Bunny.net's edge scripting runtime, JSON-LD structured data, the difference between Ruby and Rails. This is part of the appeal: clients come to him because he cares about the foundation other people skip. Don't dumb this down to corporate-friendly mush. Plain English yes; pretending not to find this stuff interesting, no.
+
+### 7. Honesty about limits
+
+"What I won't pretend to be" is a real section on the About page. The voice is comfortable saying "I'm not certified", "ask someone else", "I might be wrong", "the AI is plateauing but I might be wrong about that too". This is the same instinct that makes Stef recommend his brother Kev for marketing and the friends page for design — when someone else fits better, say so.
+
+> "If that's not enough for you, I'm probably not the right person, and that's fine."
+
+### 8. Trust the reader — except when teaching is the job
+
+On guide pages, Stef is teaching, and the job is to actually explain something the reader doesn't know — so "trust the reader" doesn't mean leave them confused. On the homepage, about, principles, and service pages, trust them more: don't justify every claim, don't restate the obvious, don't tag every paragraph with a question that handles an objection nobody raised.
+
+### 9. Politics show through choices, not slogans
+
+Stef's values come through in **what he chooses to talk about** — donating 10% to the Against Malaria Foundation, the CIC asset lock, recommending competitors, refusing to participate in harmful industries, supporting US Bandcamp colleagues unionising. They do not come through bolted-on "passionate about" or "we believe" sentences. The voice shows values through specifics; it never declares them as slogans.
+
+## Phrase pool (sparingly)
+
+Words and turns of phrase that fit the voice when they appear naturally — never as 1:1 substitution. One or two per page is plenty.
+
+- "a few quid"
+- "loads of" / "a tonne of"
+- "have a bash" / "give it a bash"
+- "a fair bit"
+- "kinda" / "sort of"
+- "down the line"
+- "in plain English"
+- "it's worth remembering that" / "it's worth bearing in mind"
+- "I'd be well impressed"
+- "by a long shot"
+- "suffice to say"
+- "the long version" / "the short version"
+- "round here" / "up here"
+- "Tell him/her that Stef sent you" (when recommending a friend)
+- "fill in the form below" (standard closer)
+
+Build this up over time as more copy gets written.
+
+## No-go list
+
+Burnt out by other northern brands, ad campaigns, and a decade of content-mill SEO copy. Avoid:
+
+- "owt" / "nowt" / "our kid"
+- "champion" as adjective ("champion job")
+- "proper" as intensifier ("proper good", "proper sorted")
+- "dead" as intensifier ("dead easy", "dead simple")
+- "ay up" / "by 'eck" / "ee bah gum"
+- Phonetic accent spelling ("'appy", "summat", "fella", "reet")
+- "me" for "my" outside quoted speech
+- "salt of the earth" / "honest as the day is long" / "no-nonsense" (as self-applied label) — clichés about northern character that signal the writer isn't northern
+- "passionate about" (anywhere, in any context)
+- "we" when it's just Stef
+- "leverage" / "synergy" / "value-add" / "best-in-class" / "world-class" — deck language
+- "supercharge" / "unlock" / "level up" (used seriously)
+- "in safe hands" / "we've got you covered" / "second to none" — dial-a-Brit content-mill phrases
+- "tried and true" (the existing copy uses "tried and tested" once; fine sparingly, but it's a cliché)
+- Em-dashes — house style is hyphens with spaces around them
+- Emoji, except where the emoji is genuinely the subject (the £6.66 → 🤘 Bandcamp easter egg is an example of doing it right)
+
+These can appear inside quotation marks if Stef is quoting someone else, or in an example showing what *not* to do. They don't belong in house voice.
+
+## Anti-patterns
+
+The specific failure modes of trying-too-hard:
+
+- **Marketing copywriter polish** — short sentences, parallel structure, punchy fragments. The opposite of Stef's natural rhythm. If a paragraph has three sentences of similar length and a closer, it's wrong.
+- **Fragment "sentences"** — "Same-day quotes." / "No lock-in." / "Just websites that work." Fragments belong in bullets and headings. In prose, every sentence has a subject and a verb.
+- **Cinematic one-line closers** — "And the rest is history." / "Chobble was born." (The principles page uses "Chobble was born" once — borderline, but it works because it's the literal end of an autobiographical paragraph, not a standalone tagline. Don't do it twice.)
+- **Punchline-delivery dashes / X / X / X — Y** — "Not WordPress, not Wix, not Squarespace — Eleventy." This is advertising structure. A hyphen used as an ordinary explanatory aside ("I bill by the hour, and setting up a Nextcloud installation takes about two hours") is fine.
+- **Lists of three with a deflating comic third** — Brian Potter satirises this; the voice doesn't do it earnestly. Stef uses flat lists of features ("fast, cheap to host, no attack surface, fully portable"); that's fine. Setting up a joke in the third slot is not.
+- **The handle-the-objection move** — "and yes, even in Prestwich" / "and yes, charities count too" / "and yes, it works on a slow connection". Pure copywriter device. Cut.
+- **Forced enthusiasm in headings** — "Let's do it!" / "Ready to supercharge your business?" / "Time to get started!". The voice is welcoming, not pep-talky. The existing "Let's do it!" closer at the bottom of a couple of service pages is the upper limit; don't escalate from there.
+- **Telling the reader the voice is plain** — using "no-nonsense" or "plain English" or "straight-talking" *about Chobble's voice* instead of just being plain. (Saying "plain English" about a guide's approach to a topic is fine — it's the self-applied label that grates.)
+- **Faux humility undercut by a sales close** — "I'm just one bloke, but I built the booking system the whole industry uses!" Confidence and honesty can coexist; an aw-shucks setup followed by a flex reads as a copywriter device.
+- **Sprinkled mid-page CTAs** — Stef has one CTA at the bottom of each page ("fill in the form below"). Don't bolt "[Contact me!]" into every other paragraph.
+- **Replacing "you" with "your business"** — adds nothing, removes warmth. Same with "small business owners like yourself" instead of "you".
+- **Generic northern markers as a substitute for voice** — anyone can sprinkle "a few quid" into a paragraph. The voice has to live in *content*, *structure*, and *opinion*, not just word choice.
+- **Hiding the politics and then dropping them as a sales paragraph** — values belong in the principles / social-impact / about pages, and show up in the specifics of what Chobble does. Don't bolt "as an anarchist I…" onto a hosting page.
+
+## Process
+
+1. Write the page in plain English first. Don't reach for the voice yet — just get the facts down.
+2. Read it aloud. Mark every sentence that sounds like it could be on a brochure, a LinkedIn post, or a content-mill SEO page.
+3. Apply the cuppa test to each marked sentence: could Stef say this to a customer over a brew at Cuckoo? If not, loosen it — usually by lengthening the sentence, adding a hedge ("I think", "it's likely that", "probably", "kinda"), breaking up the too-neat structure, or pulling in a real specific (a place name, a price, a year, a real client).
+4. Check for fake Manc — "proper", "dead", "owt", "champion", anything phonetic. Cut and replace with plain English.
+5. Check for marketing tics — punchline closers, fragment sentences, parallel-list closers, "and yes, even up here", mid-page CTAs, "passionate about". Cut.
+6. Check for hidden "we" when it should be "I". Fix.
+7. Read aloud again. If you smirk because it sounds like an advert, pull back further. If you smirk because it sounds like a tribute act of a Northerner, pull back further.
+
+## Where to use it
+
+- About page and the Principles page
+- Homepage section intros (not the SEO-heavy hero / meta copy)
+- Guides — this is where the voice lives most fully, because the guides are Stef teaching at length
+- Friends / recommended suppliers
+- Prestwich landing page
+- Service pages, especially the "Why" / "How" / "What you get" sections
+- Headlines where SEO allows
+- The "Get in touch" callouts at the bottom of pages
+
+## Where NOT to use it
+
+- Legal text (terms, privacy, complaints, accessibility statement)
+- Technical specs, accreditation, JSON-LD and other machine-readable metadata
+- Form labels, contact details, error messages
+- Meta titles and meta descriptions where SEO keywords have to lead
+- Anywhere ambiguity costs the reader money, time, or clarity
+
+Inconsistency between pages is fine. Different pages have different jobs.


### PR DESCRIPTION
## Summary

Adds a `CLAUDE.md` voice & tone guide for Stef, modelled on the structure of the Ashley/Renegade Solar guide but rewritten from the ground up to match Stef's actual register as it appears on the site (about page, principles, social impact, guides, services, friends, Prestwich landing page).

Key differences from the Ashley template:

- **No WhatsApp test.** Stef writes; he doesn't talk into a phone. Replaced with a "cuppa test" — could he say it over a brew at Cuckoo?
- **Long sentences with hedges are *the* style**, not the trap. The trap is marketing-copy polish in the other direction.
- **Nerd enthusiasm is a feature, not something to dampen** — Deno on the edge, JSON-LD, Bunny.net are all part of the voice.
- **Politics show through specifics** (CIC, 10% to AMF, recommending competitors, anarchism, vegan, anti-Big-Tech) rather than slogans.
- **Source corpus** swapped for writers/figures whose register Stef's prose actually resembles: Aaron Swartz, Cory Doctorow, Drew DeVault, Maxine Peake, Caroline Aherne, John Cooper Clarke, Mark Fisher, Owen Jones, Sleaford Mods, FSF/GNU manifestos.
- **Anti-dialect-cosplay section** leans on Stef's own AI guide, where he wrote a comic example of fake Manc ("Reet, let me tell thi abaat them Bolt Thrower lads … ..Gross.") to make exactly this point.
- **Phrase pool and no-go list** drawn from what's actually in the existing copy (or pointedly absent from it).

## Test plan

- [ ] Read through and sanity-check that the principles, examples, and quotations match Stef's actual writing
- [ ] Confirm the source corpus feels right (vs. Ashley's, which is purely Mancunian-spoken)
- [ ] Check the no-go list doesn't ban any phrasing currently in active use on the site
- [ ] Decide whether `CLAUDE.md` at the repo root is the right home, or whether it should live alongside content as `src/voice.md` with `permalink: false` like the Ashley version


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rz2a1KPBDx7WdJ7scYCU2D)_