### PR TITLE
Fix git dates showing today for all posts in CI

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

- `actions/checkout@v4` defaults to `fetch-depth: 1`, fetching only the latest commit
- With one shallow commit in history, `git log --diff-filter=A` treats every file as "Added" in that single commit, so all files get today's date
- Adding `fetch-depth: 0` fetches full history so `git log` can find the real per-file dates

## Test plan

- [ ] After merging, check the deployed site - service pages not recently edited should show their original dates, not today's
- [ ] The 10 service/prestwich pages edited in the recent voice-rewrite commit will legitimately show today (they were genuinely modified)

https://claude.ai/code/session_01Jp9A8De6n8XdKknernpzb5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jp9A8De6n8XdKknernpzb5)_