### PR TITLE
Add pulled quotes from Spencer's Elliotts ticket-platform review

### DIFF
--- a/src/reviews.md
+++ b/src/reviews.md
@@ -74,6 +74,12 @@ As Chobble is a pretty new business I don't have lots of reviews, but this page 
 >
 > *by [Andy at AS Home Furnishings](https://www.ashomefurnishings.co.uk)*
 
+> The developer at Chobble is happy to integrate with other platforms and is collaborative. I've personally worked with them on a few different projects and they are very big on interoperability - The ability for systems to exchange data and work with eachother freely and securely.
+>
+> The system is open-source, it promotes integration to other platforms and software, they're open to collaboration and will share development and it has sooo much potential.
+>
+> *by [Spencer at Elliotts Bouncy Castle Hire](https://www.elliottsbouncycastlehire.co.uk/news/2026-02-13/new-ticket-platform-initial-review)*
+
 > So we reach out in regards to ticket system they offer. I mean it game changer. Save us few bob and made easier for customers! The QR system game changer ! No more holding data on paper it now all simple
 >
 > *by Paul, tickets user*


### PR DESCRIPTION
## Summary

Pulls two choice passages from Spencer's write-up of the Chobble ticket platform on the Elliotts Bouncy Castle Hire site, focused on the dev practices side:

- The "collaborative / interoperability" passage about how Chobble works with other platforms.
- The "open-source / open to collaboration" passage.

Placed just above Paul's tickets review so the ticket-related quotes sit together at the end of the page. Attribution is `*by [Spencer at Elliotts Bouncy Castle Hire](article URL)*` to match the format established in #66.

## Test plan

- [x] `npm run build` succeeds.
- [x] Rendered HTML shows the new blockquote with two paragraphs and a linked attribution.
- [x] The attribution link points to the original article URL.

https://claude.ai/code/session_01Wjizvr6GmdhaLuu4pfCDEL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wjizvr6GmdhaLuu4pfCDEL)_