### PR TITLE
Rewrite microcontroller programming page

### DIFF
--- a/src/services/microcontroller-programming.md
+++ b/src/services/microcontroller-programming.md
@@ -1,43 +1,45 @@
 ---
 title: Microcontroller Programming
-meta_title: Microcontrollers and IoT Programming | Automations | Prestwich, Manchester | Chobble
-description: Internet of things, home automation, ESP32s, Home Assistant and more, from Chobble in Prestwich
-snippet: IoT devices, automations, and other little gadgets
+meta_title: Microcontroller & IoT Programming | ESP32 | Prestwich, Manchester | Chobble
+description: ESP32 and IoT programming for businesses - firmware, sensors, web interfaces, and prototyping through to production PCBs - Prestwich, Manchester
+snippet: IoT devices, firmware, and custom hardware integrations
 order: 16
-meta_description: Smart home gadgets and IoT programming - ESP32, Home Assistant, custom automations - open source, no cloud spying - Prestwich tech consultant
+meta_description: ESP32 and IoT programming for UK businesses - custom firmware, sensor integrations, web interfaces - prototype to production PCB - Manchester
 ---
 
-# Microcontroller programming
+# Microcontroller and IoT programming
 
-My home is full of devices like ESP32 microcontrollers, WLED strips, Tasmota lights, and ZigBee nodes.
+If you've got a piece of equipment you'd like to connect to the internet, automate, or monitor remotely, the answer is usually a small, cheap, open-source board like an ESP32 running a few lines of MicroPython. I can write the firmware, build a web interface alongside it, and help you spec and source hardware - right through to a proper PCB if you need a production run.
 
-I've hacked away on Home Assistant, Node-RED, and similar systems for many years and have become familiar with the practicalities of microcontrollers, writing scripts in MicroPython and flashing firmwares to interface with the real world through open source and interoperable protocols.
+The most interesting job I've done along these lines was for an event hire company: they wanted to add credits to an arcade machine when customers completed marketing actions - scan a QR code, sign up to a mailing list, that sort of thing. The machine had always run entirely standalone. I built the interface between their web-based promotional system and the machine's credit mechanism, so credits now get added automatically when the customer earns them, with no one needing to be in the room. It's the kind of problem I'm most useful for: devices that need to talk to systems they weren't built to talk to.
 
-## What does that mean?
+My own home has been a test bed for this kind of thing for years. I've got ESP32 boards, WLED LED strips, Tasmota lights, and ZigBee nodes all wired together with Home Assistant and Node-RED - including an automated dehumidifier that runs off surplus solar, and lighting that responds to weather, motion, and time of day. The protocols involved (MQTT, WiFi, REST APIs, serial) are familiar ground rather than things I'd be working out as I went. For Home Assistant work specifically, there's a [dedicated page](/services/home-assistant-technician/).
 
-If you'd like to "smart"-ify the electronics in your home or business, I can help you. I can install tiny, self-contained, open source chips that connect to wireless networks, log sensor data, toggle relays or switches, or power motors. I can build web interfaces to control them, which you can host on your own secure infrastructure or with me.
+## What I can help with
 
-## Who might be interested in this?
+- **Firmware development** in MicroPython - reading sensors, controlling relays and motors, managing network connections, sending data over MQTT or HTTP
+- **Web interfaces** for monitoring and control, because a working device is more useful when you can see what it's doing from a browser
+- **Integrations with your existing systems** - connecting physical devices to databases, web applications, or third-party APIs
+- **Hardware spec and sourcing** - picking appropriate components and ordering them, and if you want proper PCBs made for a production run, working through that with you too
 
-If your day-to-day business involves electronic devices and you want to customise the way they behave, then drop me a message through the contact form on this page. I'm not an electrician but I can work with you to figure out what's possible and get a prototype working.
+Everything I write is open source and yours to keep. Hand it to another developer, run it on your own infrastructure, extend it later - there's nothing stopping you.
 
-## What are some real examples?
+## Prototyping to production
 
-Here's a few projects I've worked on recently:
+A working prototype on a development board is usually the fastest way to find out whether an idea is actually feasible and where the fiddly bits are going to be. Once that's done and you know what you want, moving to a proper PCB is a straightforward next step - I can help you spec, order, and test those boards.
 
-- **Smart lighting** which reacts to the weather outdoors, motion, the sun, or all three.
-- **An automated dehumidifier** programmed to run fron surplus solar electricity, by reading data from the relay.
-- **An online arcade machine** connected to a web server to allow remote control of a previously offline device.
-- **CCTV Systems** with motion detection, viewable via a secure private VPN, hosted on your own server.
-- **Mesh WiFi networks** with 6ghz backbones for high-speed internet across multiple building floors.
-- **Web filters** which block, log, or filter internet traffic across your whole network, managed via a simple web interface.
+## Honest limits
 
-## Are you in Prestwich?
+I'm not an electrician. Anything involving mains voltage or real electrical safety needs someone qualified for that - [Ashley at Renegade Solar](/examples/renegade-solar/) is an electrician who's familiar with this kind of work, and I can put you in touch if the project calls for it. What I can cover is everything on the software and electronics side: firmware, protocols, interfaces, and integrations.
 
-If you're local to Prestwich, even better! We can test your device together on-premises. And if we need to work with a local electrician, I know one who can help who is familiar with microcontrollers.
+I'm also not set up for safety-critical applications or anything needing formal certification - a smart dehumidifier or an arcade machine credit trigger is one thing, but anything that has to be certified to a safety standard is something to take to someone else.
 
-## Let's talk!
+## Pricing
 
-If this sounds good then **drop me a message through the contact form on this page to get the ball rolling**. We'll come up with a plan, build a prototype, and iterate on it until we've got something perfect for your needs.
+Same hourly rate as everything else: **£200/hour** for commercial work, **£100/hour** if you qualify for the [discount](/prices/) (charities, co-ops, artists, musicians, vegan businesses, renewable energy companies). The initial chat is free and I'll give you an estimate before starting anything.
 
-I use open source tools which give you complete ownership over your data and code, so you'll own it forever.
+A prototype build - working out the hardware, writing the firmware, and putting together a basic web interface - is typically somewhere in the 4-10 hour range depending on how complex the integration is.
+
+## Get in touch
+
+If you've got something in mind, fill in the form below.


### PR DESCRIPTION
## Summary

- Replaces generic AI-smelling content (rhetorical-question headings, "Let's talk!", scattered bold CTAs, "we" throughout, no named proof) with a page that passes the voice checklist in CLAUDE.md
- The arcade machine client story now leads as the anchor example — specific, paid, and genuinely distinctive
- Home projects (dehumidifier, lighting, WLED/Tasmota/ZigBee) moved to supporting role, with a link to the Home Assistant page to avoid duplicating that content
- Adds a missing Pricing section (£200/£100/hr, same as everywhere else, 4-10hr prototype estimate)
- Adds an Honest limits section naming Ashley at Renegade Solar for electrical work, and flagging that safety-critical/certified work is out of scope
- Drops the mesh WiFi, CCTV, and web filter bullets (network admin, not microcontroller work per Stef)
- One CTA at the bottom, no mid-page CTAs

## Test plan

- [ ] Read aloud — no sentences that sound like a brochure or a costume Northerner
- [ ] Check all intra-links resolve: `/services/home-assistant-technician/`, `/examples/renegade-solar/`, `/prices/`
- [ ] Confirm no "we" where it should be "I"
- [ ] Confirm no em-dashes (hyphens only)

https://claude.ai/code/session_01S5VBQXRhCkbZegqDWGmCRF

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5VBQXRhCkbZegqDWGmCRF)_