### PR TITLE
Rewrite Wix help page following the page-rewrite playbook

### DIFF
--- a/src/services/wix-site-edits.md
+++ b/src/services/wix-site-edits.md
@@ -1,115 +1,71 @@
 ---
 title: Wix Website Edits & Help
-meta_title: Wix Website Help | Prestwich, Manchester | Chobble
-description: Struggling with Wix's overwhelming interface? I'll help you navigate the complex features without the marketing fluff or vendor lock-in.
-snippet: Navigate Wix's confusing interface with unbiased expert help
+meta_title: Wix Help & Website Edits | Prestwich, Manchester | Chobble
+description: Honest help with an existing Wix site - sorting out specific problems, or working out whether it's worth moving somewhere else
+snippet: Honest help with an existing Wix site, or working out if it's time to leave
 order: 3
-meta_description: Stuck with Wix? I'll help navigate the confusing menus - honest advice about staying or leaving - no affiliation with Wix - Manchester web developer
+meta_description: Wix help in Manchester - fixing and configuring existing Wix sites, honest advice on whether to migrate - no affiliation with Wix - Prestwich web developer
 ---
 
-# Stuck with your Wix site? I can help
+# Stuck with Wix? I can help
 
-**The problem with Wix isn't that it's rubbish** - it's that the interface can feel completely overwhelming. Because Wix supports everything under the sun, finding what you need feels like hunting for a needle in a haystack. There's often three different and non-obvious ways to do the same thing.
+Wix is a perfectly reasonable way to get something online quickly without writing any code, and plenty of small businesses are well served by it. Where people tend to get stuck is a bit further down the line - the interface is so packed with options that finding the one you actually need feels like hunting through a kitchen drawer full of cables, the site's started to feel sluggish, or the monthly bill keeps creeping up and you're starting to wonder whether you're getting your money's worth out of it.
 
-If you've got graphic design skills, you can make a Wix site look decent. But making it perform well is where most people get stuck. Wix imports loads of JavaScript libraries whether you need them or not, which makes sites feel sluggish. Getting around these limitations means reading and understanding lots of technical documentation - which is where I come in.
+I've no relationship with Wix and nothing to sell you on their behalf, so there's nothing in it for me whichever way this goes. I can help you get your existing site doing what you need it to do, or give you an honest read on whether moving somewhere else would actually serve you better - and I'll say so plainly if the answer turns out to be "stay where you are, it's fine as it is".
 
-## What I actually do for Wix users
+## What I can help with on your existing site
 
-**I'm not affiliated with Wix** - which means I'll give you honest advice about whether staying on their platform makes sense for your business. My job is to save you money and headaches in the long run, not upsell you anything.
+- **Finding the setting that's hiding from you** - Wix buries a lot of useful options several menus deep, and I can usually track down where something lives faster than working through their help articles
+- **Setting up specific features properly** - online stores, booking systems, member areas, galleries, contact forms, that sort of thing
+- **Performance work within Wix's limits** - there's only so much you can do about how much JavaScript Wix loads by default, but stripping out unused apps, trackers and oversized images often makes a real difference
+- **Getting your content out** - if you do decide to leave, I can help export what you've built so it's in a shape that's ready to bring across to wherever you're going next
 
-Here's how I help with Wix sites:
+You'd give me temporary contributor access through Wix's own collaboration tools (not your password - they have proper ways of doing this), I'll get on with the work, and you can take my access away again once it's done.
 
-**Navigate the overwhelming interface** - I'll dig through Wix's menus to help you set up the features you need, whether that's eCommerce, booking systems, member areas, or fancy galleries.
+## Whether it's worth moving on
 
-**Make sense of their documentation** - Years of working with APIs and technical docs means I can translate Wix's often confusing instructions into actionable steps.
+I migrated [Renegade Solar](/examples/renegade-solar/)'s website off Wix. Ashley's old site was painfully slow, ranking for almost nothing beyond his own business name, and bringing in maybe one enquiry a year - and on top of that he had test products stuck in Wix's e-commerce system that he couldn't work out how to remove. I rebuilt it as a static [Eleventy](/services/eleventy-developer/) site that he updates himself through PagesCMS, and it now gets him roughly an enquiry a week, loads in under a second, and costs him less to host every month than Wix did.
 
-**Improve site performance** - I'll identify what's slowing your site down and work within Wix's constraints to speed things up where possible.
+That's not the right call for everyone, though - plenty of Wix sites are doing exactly what their owners need them to do, and a migration costs money up front that's not worth spending if what you've got is working fine. If you're not sure which camp you're in, my [technical consultancy](/services/technical-advice/) service is built for working through exactly that question, and the [website migrations](/services/website-migrations/) page explains what the move itself actually involves.
 
-**Export your data safely** - If you decide Wix isn't right for you, I can help extract your content and get it ready for a better-suited platform.
+## Pricing
 
-## Specific Wix features I can set up
+Same as everything else I do - a flat **£200 an hour**, or **£100 an hour** for charities, co-ops, artists, musicians, vegan businesses and renewable energy companies (the [charity web development](/services/charity-web-development/) page has the full list and the reasoning behind it). Most "I can't find how to set this up" jobs take an hour or two; bigger ones, like setting up a shop from scratch or untangling years of accumulated settings, run longer - and I'll always give you an estimate before starting.
 
-If you need any of these implemented on your Wix site, I can dig through their interface and documentation to get them working properly:
+## Questions
 
-- **Online stores** using Wix eCommerce with payment processing and inventory management
-- **Booking systems** with Wix Scheduling for appointments, classes, or events
-- **Member-only areas** using Wix's permissions system for exclusive content
-- **Product databases** that populate your site automatically from spreadsheets or APIs
-- **Media galleries** for photos, videos, or music with proper optimization
-- **Contact forms** with custom fields, validation, and email automation
-- **Blog integration** with SEO-friendly URLs and social sharing
-- **Third-party integrations** connecting Wix to other tools you use
-- **Custom animations** and interactive elements (within Wix's constraints)
-- **Multi-language sites** with proper URL structure and content management
+<details>
+<summary><strong>Can you just fix the one thing that's bugging me?</strong></summary>
 
-The full scope of what's possible is huge - [Wix's developer documentation](https://dev.wix.com/) gives you an idea of just how much functionality they pack in. The problem is that finding and configuring what you need can take hours of clicking through menus and reading confusing help articles.
+Yes - that's most of what this looks like in practice. You give me temporary access, I sort out the specific thing (or work out why it isn't doing what you expect), and hand control back. Jobs like this usually take an hour or two.
 
-## The honest truth about Wix
+</details>
 
-Wix works fine if your website isn't crucial to your business and you're happy with the ongoing costs. But if your site is an important sales funnel, you'll quickly hit its limitations. **Wix can change their prices or break your site's functionality overnight** - I've seen customers whose sites suddenly stopped working after Wix changed how their JavaScript worked. When they complained, Wix blamed the customer.
+<details>
+<summary><strong>Can you make my Wix site load faster?</strong></summary>
 
-This kind of nightmare simply can't happen with a [static website](/services/static-websites) built to your specifications. If long-term stability and cost control matter to your business, consider a [website migration](/services/website-migrations) to cheaper, more reliable hosting.
+Up to a point. I can strip out unused apps and trackers, optimise images, and tidy up whatever's adding weight to the page, and that often genuinely helps. What I can't do is make a Wix site load like a static one - the platform itself does a fair bit of work in the visitor's browser that a static site simply doesn't need to do. If speed really matters to your business, it's worth knowing that ceiling exists before spending money chasing it.
 
-## Remote Wix help - no lengthy contracts
+</details>
 
-All Wix work is done remotely. You'll give me temporary access to your site, I'll crack on with the work, then explain exactly what I did in as much detail as you want. **I charge by the hour with transparent pricing** - probably much cheaper than Wix's dedicated support or ongoing consultant fees.
+<details>
+<summary><strong>Will you build me a new website on Wix?</strong></summary>
 
-**Need broader website strategy advice?** I've used Wix, WordPress, Squarespace, and I've built at least a hundred custom websites in my career. My [technical consultancy](/services/technical-advice) service can help you choose the right platform for your actual needs, not just what's easiest to sell you.
+No - it's not a platform I'd choose to build on, and there are people out there who specialise in it far more than I do. If you're starting from scratch, I'd point you toward a [static site](/services/static-websites/) for most small businesses, or [WordPress](/services/wordpress-developer/) for the cases where you genuinely need the extra moving parts.
 
-**Already know your site needs improvement but not sure where to start?** A [website content audit](/services/website-content-advice) will give you a prioritised list of what's worth fixing.
+</details>
 
-**Worried about technical SEO issues?** My [SEO audit service](/services/seo-audits/) uses industry-standard tools to identify performance problems that Wix's built-in analytics won't show you.
+<details>
+<summary><strong>What if I want to leave Wix later?</strong></summary>
 
-**If you're wrestling with Wix's interface or wondering whether it's the right fit for your business, send me a message through the form below and I'll give you straight answers.**
+I can help with that - exporting your content and images and getting them into a shape that works wherever you're moving to. The earlier you start thinking about it, the easier it tends to be: five years of accumulated blog posts and product pages takes a lot longer to untangle than one year's worth.
 
-## Local Wix help in Prestwich & Manchester
+</details>
 
-While all my Wix work can be done remotely, **if you're based in Prestwich or nearby areas of Manchester**, I'm happy to meet up for a proper chat about your website strategy. Sometimes it's easier to explain complex technical concepts face-to-face, especially when we're weighing up whether to stick with Wix or move to something better.
+## Local help in Prestwich
 
-I can meet you at a local café, your office, or wherever suits you best. This works particularly well if you're trying to decide between platforms or need to understand the long-term implications of your website choices. **No obligation** - I'm always happy to help local businesses make informed decisions, even if that means recommending you sort your Wix issues yourself rather than paying me.
+I'm based in Prestwich, just north of Manchester, and I'm happy to meet local businesses for a coffee to look through what's going on with your site together - sometimes it's a lot quicker to point at a screen than to describe a Wix menu over email. Other [Prestwich-focused services](/prestwich/) are on the main Prestwich page.
 
-Check out my other [Prestwich-focused services](/prestwich/) if you're a local business looking for broader web design or [SEO help](/prestwich/search-engine-optimisation/).
+## Get in touch
 
-## Frequently asked questions
-
-**Q: How much does Wix help cost compared to just paying Wix directly?**
-
-A: I charge by the hour with no ongoing fees, which often works out much cheaper than Wix's premium support or hiring a Wix Partner who'll want monthly retainers. A typical "I can't figure out how to set up my booking system" job might take 2-3 hours of my time versus months of wrestling with it yourself or paying someone £200+ per month indefinitely.
-
-**Q: My Wix site is really slow - can you fix that?**
-
-A: I can definitely help identify what's slowing it down and work within Wix's constraints to improve things. But honestly? Wix sites are inherently heavy because they load tons of JavaScript whether you need it or not. If site speed is crucial for your business, you might be better off with a [static website](/services/static-websites) that loads in milliseconds rather than seconds.
-
-**Q: Should I stick with Wix or move to something else?**
-
-A: Depends entirely on your needs and tolerance for ongoing costs. Wix is fine for hobby sites or businesses where the website isn't a critical sales tool. But if your site generates revenue, the performance limitations and vendor lock-in become expensive problems. I'll give you honest advice about whether it makes financial sense to stay or [migrate elsewhere](/services/website-migrations).
-
-**Q: What if I want to leave Wix later - will I lose everything?**
-
-A: Not if you plan ahead. I can export your content, images, and data in formats that work with other platforms. The sooner you make this change, the easier it is. Leaving Wix after five years of adding content is much more complex than leaving after one.
-
-**Q: How does remote Wix work?**
-
-A: You'll give me temporary editor access to your Wix site (not your login details - Wix has proper collaboration tools). I'll do the work, document exactly what I changed, then remove my access. You stay in control of your site throughout. Most jobs take a few hours to a couple of days depending on complexity.
-
-**Q: Is it worth paying for Wix's own premium support?**
-
-A: Wix support will only help you use Wix tools in ways Wix approves of. They won't tell you if a different platform would suit you better, or help you work around Wix's limitations. I'm not trying to sell you a Wix subscription, so I can give you genuinely unbiased advice about what makes sense for your business.
-
-**Q: What can't be fixed on Wix?**
-
-A: Wix's fundamental architecture - you can't make it load as fast as a properly built static site, and you can't escape their hosting costs. If those are deal-breakers, no amount of tweaking will solve them. I'll be upfront about what's possible and what isn't.
-
-**Q: How do you know which platform is best for different businesses?**
-
-A: I've built sites on everything - Wix, Squarespace, WordPress, and hundreds of custom static sites. I've seen what works for different types of businesses and budgets. My [technical consultancy](/services/technical-advice) service exists specifically to help people make informed platform decisions without the sales pressure.
-
-**Q: What happens if Wix breaks my site again like you mentioned?**
-
-A: You're stuck with whatever Wix decides to do - it's their platform, their rules. This is why I always discuss the risks of platform dependency with clients. With a static site, you control the code and hosting, so this scenario simply can't happen.
-
-**Q: I just want a simple brochure site - should I even bother with Wix?**
-
-A: Probably not. Wix's interface is overkill for simple sites, and you'll pay monthly fees forever for features you don't need. A [static website](/services/static-websites) would cost less upfront, load faster, and have no ongoing hosting fees. Save Wix for when you need dynamic features like booking systems or member areas.
-
-**Still got questions? send me a message through the form below - I'm happy to chat about your specific situation without any obligation.**
+Fill in the form below and tell me what's going on with your site. I'll reply within a day with honest advice about whether I can help, and roughly how long it'd take.


### PR DESCRIPTION
## Summary

Following the `page-rewrite-plan.md` playbook (PR #70), I picked `src/services/wix-site-edits.md` as the next target - it was the clearest case of AI-smelling content left on the site:

- Three bolded rhetorical-question mid-page CTAs ("**Need broader website strategy advice?**", "**Already know your site needs improvement...**", "**Worried about technical SEO issues?**") - exactly the "handle-the-objection" pattern CLAUDE.md warns against
- A 12-question "Q: ... A: ..." FAQ block that doesn't match the `<details><summary>` pattern every other service page on the site uses
- Unverifiable claims ("I've built at least a hundred custom websites in my career") that don't appear anywhere else on the site

## What changed

- Replaced the generic "Wix can change their prices overnight, I've seen customers..." complaints with a real, named, linkable example: [Renegade Solar](/examples/renegade-solar/), where Ashley's old Wix site got about one enquiry a year (with test products stuck in Wix's e-commerce system he couldn't remove), and the rebuilt static Eleventy site now gets roughly one enquiry a week, loads in under a second, and costs less to host - all sourced from the existing example page and guide
- Added an honest "Whether it's worth moving on" section that doesn't oversell migration - it says plainly that plenty of Wix sites are doing fine as they are, and points to `/services/technical-advice/` and `/services/website-migrations/` for working that out
- Trimmed the FAQ to four genuinely useful questions in the site's `<details>` format, including an honest "Will you build me a new website on Wix? No" answer (matches the "honesty about limits" principle - Stef doesn't build on Wix and says so)
- One CTA at the bottom ("fill in the form below"), no scattered mid-page CTAs
- Pricing section uses the same £200/£100 flat-rate framing as every other service page

## Test plan

- [x] `npm run build` runs clean (106 files, no errors)
- [x] All intra-links resolve: renegade-solar, eleventy-developer, technical-advice, website-migrations, charity-web-development, static-websites, wordpress-developer, prestwich
- [x] Grepped against the CLAUDE.md no-go list (em-dashes, "we" as company, "passionate about", fake-Manc, etc.) - no hits
- [ ] Read aloud for the cuppa test (Stef)

https://claude.ai/code/session_01UEb6AWySiM4yjhzxYJ5LpG


---
_Generated by [Claude Code](https://claude.ai/code/session_01UEb6AWySiM4yjhzxYJ5LpG)_