### PR TITLE
Rewrite This & That and Play Safe example pages in house voice

### DIFF
--- a/src/examples/play-safe-play-inspection.md
+++ b/src/examples/play-safe-play-inspection.md
@@ -32,8 +32,8 @@ The site uses [PagesCMS](https://pagescms.org/) for content editing, with the CM
 
 ## Hosting and performance
 
-Like all Chobble Template sites, this is hosted on blazing fast Bunny CDN servers. The site gets **100% scores across the board in Lighthouse** - performance, accessibility, best practices, and SEO all maxed out. That's the advantage of static site generation combined with a well-optimised template and global CDN hosting.
+Like all Chobble Template sites, this one is hosted on Bunny's CDN. It scores 100% in all four Lighthouse categories - performance, accessibility, best practices, and SEO - which is what you'd expect from a static site built on a well-sorted template and served from a CDN close to whoever's visiting.
 
 Because it's built on the Chobble Template, the site also gets periodic updates as I improve the base template. And I have a bunch of other bits set up for each customer too - privacy-respecting analytics through GoatCounter (GDPR compliant, no cookie banners needed), email addresses through Purelymail, and Google Search Console configured for tracking search performance.
 
-**If you'd like a professional website like this for your play inspection or similar safety inspection business, get in touch through the contact form on this page!**
+If you'd like a website like this for your play inspection or another kind of safety inspection business, fill in the form below.

--- a/src/examples/this-and-that.md
+++ b/src/examples/this-and-that.md
@@ -9,57 +9,47 @@ colour: white
 
 # This & That cafe website
 
-**Proving that restaurants don't need complicated websites - just fast, honest ones that answer customer questions immediately**
-
 - **Client:** This & That Cafe, Manchester
 - **Services:** Website hosting and social media management
 - **Website:** [ThisAndThatCafe.co.uk](https://www.thisandthatcafe.co.uk)
 - **Source code:** [on git.chobble.com](https://git.chobble.com/hosted-by-chobble/this-and-that)
 
-This & That is a Manchester institution, famous for its "rice and three" curry dishes. Operating since 1984, it's a beloved part of the Northern Quarter's food scene.
+This & That is a Manchester institution, famous for its "rice and three" curry dishes. It's been going since 1984 and it's a fixture of the Northern Quarter, tucked down an alley that's easy to walk straight past.
 
 ![This & That's website homepage. The cafe is easy to miss, so the photo shows the alley visitors need to find as its header image. There are two main links, "Home" and "Menu", and we can see TripAdvisor reviews and the start of a description of the business](/assets/examples/this-and-that.png)
 
-## From domain disaster to digital success
+## Reclaiming the domain
 
-When I started working with This & That in 2016, **their website had expired and been claimed by domain squatters** who put up a spammy landing page. I helped them reclaim their domain through Nominet, which built trust, then set up a new site mirroring their old content.
+When I started working with them in 2016, their old website had expired and been picked up by domain squatters, who'd stuck a spammy landing page on it. The first job was getting the domain back through Nominet, which sorted the immediate problem, and then I set up a new site mirroring the content they'd had before.
 
-**The site costs just £10/month** - qualifying for my "no support" hosting package because changes are so infrequent. This reflects the business perfectly - they haven't really changed since the 1980s, and neither has their website approach. Sometimes the best digital strategy is keeping things simple and reliable.
+It runs on my £10/month hosting - the "no support" package, because the site changes so rarely that there's not much to support. That suits the business: This & That has barely changed since the 1980s, and its website doesn't need to either.
 
-## Website approach
+## What the site does
 
-I maintain a simple, fast-loading static website that focuses on what visitors need most. **The menu is immediately accessible** - unlike many restaurant sites that hide menus in PDFs or behind multiple clicks. On This & That's site, the current menu and prices are right there on an HTML page that loads instantly on any device.
+It's a simple, fast-loading static site built around the one thing people nearly always turn up looking for, which is the menu. The current dishes and prices sit right there on an ordinary HTML page that loads instantly on a phone, so someone googling "this and that menu" while they're walking round town gets what they want straight away.
 
-**Site traffic numbers are always high** with lots of people googling the menu and landing on it immediately. This is much faster compared to sites that make customers navigate complex interfaces just to see what's on offer.
-
-The site has gradually expanded over the years - adding a vegan menu page, reviews sections, more contact links - but very slowly, which mirrors how the business operates. **Changes happen in less than 24 hours** when needed, but they're rare because the business itself rarely changes.
-
-Everything is designed for clarity and ease of access, especially for mobile users who might be looking up the cafe while walking around Manchester.
+The site has grown a bit over the years - a vegan menu page, a reviews section, a few more contact links - but slowly, the same way the cafe does. When something does need changing I'll usually have it done within a day, though that doesn't come up often.
 
 ## Technical details
 
-The site is built as a [static "Jekyll" website](/services/static-websites/) that achieves perfect Lighthouse performance scores. It's fully responsive, working beautifully on everything from small phones to large desktop monitors. The site includes minimal JavaScript for essential functionality like the Google Maps embed and privacy-preserving analytics via GoatCounter.
+The site is built as a [static "Jekyll" website](/services/static-websites/) with perfect Lighthouse performance scores, and it works the same on a small phone as on a big monitor. There's only a little JavaScript, for the Google Maps embed and for GoatCounter, which is privacy-preserving analytics that doesn't need a cookie banner.
 
-During the COVID-19 pandemic, I quickly added integration with Deliveroo to help the business continue serving customers during lockdowns. I track the site's search engine rankings using SerpBear to ensure it maintains visibility for key search terms.
+During the COVID lockdowns I added a Deliveroo integration fairly quickly so they could keep serving while the dining room was shut. I keep an eye on where the site ranks for its key search terms using SerpBear.
 
-## Social media management
+## Social media
 
-I handle their Facebook page, **posting once or twice a month** - no overwhelming daily updates that restaurants often feel pressured to do. **The best performing content is when celebrities visit the cafe** - these posts get massive engagement and bring in new customers.
+I look after their Facebook page, posting once or twice a month rather than the daily grind restaurants often feel they're supposed to keep up. The posts that do best by a mile are the ones where a celebrity's been in - those bring in new customers.
 
-I've set up Google Alerts so whenever someone reviews This & That or mentions them in an article, I know about it straight away. I share these on social media and occasionally copy the best ones over to the website, which keeps everything looking fresh without constant work.
+I've got Google Alerts set up so I hear about it whenever someone reviews the cafe or mentions it in an article. I'll share the good ones on social media and now and then copy one over to the website, which keeps things looking current without much ongoing work.
 
-When This & That get approached about partnerships or online listings (which happens a lot to successful restaurants), they forward me the emails and **I tell them whether it's worth doing or just someone trying to get money out of them**. This saves them from getting ripped off by digital marketing companies.
+Successful restaurants get approached about partnerships and online listings constantly, so when one of those emails lands they forward it to me and I tell them whether it's worth bothering with or whether it's just someone after their money. It saves them getting talked into things they don't need.
 
-## Why this works
+## Why it works
 
-**The site reflects the business perfectly** - very simple, straightforward, honest, and rarely changing. It's super reliable, like the cafe itself. This consistency has been running successfully since 2016, providing exactly what visitors need without unnecessary bells and whistles.
-
-**This & That's online presence maintains their reputation** as a no-nonsense, quality-focused establishment that's all about the food. The website doesn't try to be flashy or trendy - it just works, loads fast, and gets people the information they need.
-
-For restaurants that focus on quality over gimmicks, this approach proves you don't need to spend thousands on complicated websites that require constant updating. **Sometimes the best digital strategy is reliability and simplicity.**
+The site matches the business - simple, honest, reliable, and rarely changing. It's been doing its job since 2016 without any fuss, giving visitors exactly what they came for. It doesn't try to be flashy, because the cafe isn't, and a place whose whole appeal is the food doesn't need a website getting in the way of finding it.
 
 ## Source code
 
-The complete source code for this project is available [on my Git forge](https://git.chobble.com/hosted-by-chobble/this-and-that). If you'd like a site like it, you can clone the repo - but I'd advise starting from the newer [Chobble Template](https://git.chobble.com/chobble/chobble-template) instead.
+The complete source code is available [on my Git forge](https://git.chobble.com/hosted-by-chobble/this-and-that). You're welcome to clone it if you'd like a site like it, though I'd point you at the newer [Chobble Template](https://git.chobble.com/chobble/chobble-template) as a starting point instead.
 
-**Is your restaurant website slow, expensive, or confusing? [Contact me](/contact/) to discuss a simple, reliable website that works for your business and is really easy to manage.**
+If your restaurant's website is slow, expensive, or hard to change, fill in the form below and we can talk about a simpler one.


### PR DESCRIPTION
## What

Two example/case-study pages rewritten to match the site's voice guide (`CLAUDE.md`), cutting AI/marketing tics while keeping every factual claim.

## `examples/this-and-that.md` (heavy rewrite)

Removed:
- The bolded thesis fragment under the H1 ("Proving that restaurants don't need complicated websites…").
- The cinematic heading "From domain disaster to digital success".
- The bolded fragment openers on nearly every paragraph.
- The PDF-menu strawman ("unlike many restaurant sites that hide menus in PDFs…") that the voice guide names explicitly.
- "no-nonsense" (a no-go label) and the duplicated "Sometimes the best digital strategy…" one-line closer.
- The rhetorical-question CTA, replaced with the single form-below close.

Kept the real specifics: the Nominet domain reclaim, £10/month no-support hosting, the COVID Deliveroo integration, SerpBear, GoatCounter, the once-or-twice-a-month social posting, and the celebrity-visit detail.

## `examples/play-safe-play-inspection.md` (light touch)

This page was mostly fine. Fixed:
- "blazing fast Bunny CDN servers" → plain description (dropped the overselling modifier the guide names).
- The "100% scores across the board… all maxed out" brag, keeping the real 100% Lighthouse fact without the puffery.
- The over-eager exclamation closer, replaced with the standard form-below close.

## Notes

- Separate branch/PR from the service-page voice work in #74, since these are independent changes.
- No facts invented or changed - only tone. Verified with a local Eleventy build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ua2w13rAnsuz8xnVu4QAEN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ua2w13rAnsuz8xnVu4QAEN)_